### PR TITLE
Make sample qc exprs return an array instead of a map

### DIFF
--- a/core/src/main/scala/io/projectglow/sql/expressions/MomentAggState.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/MomentAggState.scala
@@ -60,15 +60,16 @@ case class MomentAggState(
   def update(element: Int): Unit = update(element.toDouble)
   def update(element: Float): Unit = update(element.toDouble)
 
+  def toInternalRow(row: InternalRow): InternalRow = {
+    row.update(0, if (count > 0) mean else null)
+    row.update(1, if (count > 0) Math.sqrt(m2 / (count - 1)))
+    row.update(2, if (count > 0) min else null)
+    row.update(3, if (count > 0) max else null)
+    row
+  }
+
   def toInternalRow: InternalRow = {
-    new GenericInternalRow(
-      Array(
-        if (count > 0) mean else null,
-        if (count > 0) Math.sqrt(m2 / (count - 1)) else null,
-        if (count > 0) min else null,
-        if (count > 0) max else null
-      )
-    )
+    toInternalRow(new GenericInternalRow(4))
   }
 }
 

--- a/core/src/main/scala/io/projectglow/sql/expressions/MomentAggState.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/MomentAggState.scala
@@ -60,11 +60,14 @@ case class MomentAggState(
   def update(element: Int): Unit = update(element.toDouble)
   def update(element: Float): Unit = update(element.toDouble)
 
-  def toInternalRow(row: InternalRow): InternalRow = {
-    row.update(0, if (count > 0) mean else null)
-    row.update(1, if (count > 0) Math.sqrt(m2 / (count - 1)) else null)
-    row.update(2, if (count > 0) min else null)
-    row.update(3, if (count > 0) max else null)
+  /**
+   * Writes the mean, stdev, min, and max into the input row beginning at the provided offset.
+   */
+  def toInternalRow(row: InternalRow, offset: Int = 0): InternalRow = {
+    row.update(offset, if (count > 0) mean else null)
+    row.update(offset + 1, if (count > 0) Math.sqrt(m2 / (count - 1)) else null)
+    row.update(offset + 2, if (count > 0) min else null)
+    row.update(offset + 3, if (count > 0) max else null)
     row
   }
 

--- a/core/src/main/scala/io/projectglow/sql/expressions/MomentAggState.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/MomentAggState.scala
@@ -62,7 +62,7 @@ case class MomentAggState(
 
   def toInternalRow(row: InternalRow): InternalRow = {
     row.update(0, if (count > 0) mean else null)
-    row.update(1, if (count > 0) Math.sqrt(m2 / (count - 1)))
+    row.update(1, if (count > 0) Math.sqrt(m2 / (count - 1)) else null)
     row.update(2, if (count > 0) min else null)
     row.update(3, if (count > 0) max else null)
     row

--- a/core/src/main/scala/io/projectglow/sql/expressions/PerSampleSummaryStatistics.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/PerSampleSummaryStatistics.scala
@@ -23,12 +23,11 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.SparkEnv
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow}
 import org.apache.spark.sql.catalyst.expressions.aggregate.{ImperativeAggregate, TypedImperativeAggregate}
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData, GenericArrayData}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
-
 import io.projectglow.common.{GlowLogging, VariantSchemas}
 import io.projectglow.sql.util.ExpectsGenotypeFields
 
@@ -41,7 +40,8 @@ case class SampleSummaryStatsState(var sampleId: String, var momentAggState: Mom
  * sample in a cohort. The field is determined by the provided [[StructField]]. If the field does
  * not exist in the genotype struct, an analysis error will be thrown.
  *
- * The return type is a map of sampleId -> summary statistics.
+ * The return type is an array of summary statistics. If sample ids are included in the input,
+ * they'll be propagated to the results.
  */
 case class PerSampleSummaryStatistics(
     genotypes: Expression,
@@ -54,38 +54,52 @@ case class PerSampleSummaryStatistics(
 
   override def children: Seq[Expression] = Seq(genotypes)
   override def nullable: Boolean = false
-  override def dataType: DataType = MapType(StringType, MomentAggState.schema)
+
+  override def dataType: DataType =
+    if (optionalFieldIndices(0) != -1) {
+      ArrayType(MomentAggState.schema.add(VariantSchemas.sampleIdField))
+    } else {
+      ArrayType(MomentAggState.schema)
+    }
 
   override def genotypesExpr: Expression = genotypes
-  override def genotypeFieldsRequired: Seq[StructField] = Seq(VariantSchemas.sampleIdField, field)
+  override def genotypeFieldsRequired: Seq[StructField] = Seq(field)
+  override def optionalGenotypeFields: Seq[StructField] = Seq(VariantSchemas.sampleIdField)
 
   override def createAggregationBuffer(): ArrayBuffer[SampleSummaryStatsState] = {
     mutable.ArrayBuffer[SampleSummaryStatsState]()
   }
 
   override def eval(buffer: ArrayBuffer[SampleSummaryStatsState]): Any = {
-    val keys = new GenericArrayData(buffer.map(s => UTF8String.fromString(s.sampleId)))
-    val values = new GenericArrayData(buffer.map(s => s.momentAggState.toInternalRow))
-    new ArrayBasedMapData(keys, values)
+    if (optionalFieldIndices(0) == -1) { // no sample ids
+      new GenericArrayData(buffer.map(s => s.momentAggState.toInternalRow))
+    } else {
+      new GenericArrayData(buffer.map { s =>
+        val outputRow = new GenericInternalRow(MomentAggState.schema.length + 1)
+        s.momentAggState.toInternalRow(outputRow)
+        outputRow.update(MomentAggState.schema.length, UTF8String.fromString(s.sampleId))
+        outputRow
+      })
+    }
   }
 
   private lazy val updateStateFn: (MomentAggState, InternalRow) => Unit = {
     field.dataType match {
       case FloatType =>
         (state, genotype) => {
-          state.update(genotype.getFloat(genotypeFieldIndices(1)))
+          state.update(genotype.getFloat(genotypeFieldIndices(0)))
         }
       case DoubleType =>
         (state, genotype) => {
-          state.update(genotype.getDouble(genotypeFieldIndices(1)))
+          state.update(genotype.getDouble(genotypeFieldIndices(0)))
         }
       case IntegerType =>
         (state, genotype) => {
-          state.update(genotype.getInt(genotypeFieldIndices(1)))
+          state.update(genotype.getInt(genotypeFieldIndices(0)))
         }
       case LongType =>
         (state, genotype) => {
-          state.update(genotype.getLong(genotypeFieldIndices(1)))
+          state.update(genotype.getLong(genotypeFieldIndices(0)))
         }
     }
   }
@@ -100,14 +114,18 @@ case class PerSampleSummaryStatistics(
 
       // Make sure the buffer has an entry for this sample
       if (i >= buffer.size) {
-        val sampleId = genotypesArray
-          .getStruct(buffer.size, genotypeStructSize)
-          .getString(genotypeFieldIndices.head)
+        val sampleId = if (optionalFieldIndices(0) != -1) {
+          genotypesArray
+            .getStruct(buffer.size, genotypeStructSize)
+            .getString(optionalFieldIndices(0))
+        } else {
+          null
+        }
         buffer.append(SampleSummaryStatsState(sampleId, MomentAggState()))
       }
 
       val struct = genotypesArray.getStruct(i, genotypeStructSize)
-      if (!struct.isNullAt(genotypeFieldIndices(1))) {
+      if (!struct.isNullAt(genotypeFieldIndices(0))) {
         updateStateFn(buffer(i).momentAggState, genotypesArray.getStruct(i, genotypeStructSize))
       }
       i += 1
@@ -130,7 +148,9 @@ case class PerSampleSummaryStatistics(
     )
     var i = 0
     while (i < buffer.size) {
-      require(buffer(i).sampleId == input(i).sampleId, s"Samples did not match at position $i")
+      require(
+        buffer(i).sampleId == input(i).sampleId,
+        s"Samples did not match at position $i (${buffer(i).sampleId}, ${input(i).sampleId})")
       buffer(i).momentAggState =
         MomentAggState.merge(buffer(i).momentAggState, input(i).momentAggState)
       i += 1

--- a/core/src/main/scala/io/projectglow/sql/util/ExpectsGenotypeFields.scala
+++ b/core/src/main/scala/io/projectglow/sql/util/ExpectsGenotypeFields.scala
@@ -30,23 +30,27 @@ trait ExpectsGenotypeFields extends Expression {
 
   protected def genotypeFieldsRequired: Seq[StructField]
 
+  protected def optionalGenotypeFields: Seq[StructField] = Seq.empty
+
+  private lazy val gStruct = genotypesExpr
+    .dataType
+    .asInstanceOf[ArrayType]
+    .elementType
+    .asInstanceOf[StructType]
+
   protected lazy val genotypeFieldIndices: Seq[Int] = {
-    val gStruct = genotypesExpr
-      .dataType
-      .asInstanceOf[ArrayType]
-      .elementType
-      .asInstanceOf[StructType]
     genotypeFieldsRequired.map { f =>
       gStruct.indexWhere(SQLUtils.structFieldsEqualExceptNullability(f, _))
     }
   }
 
+  protected lazy val optionalFieldIndices: Seq[Int] = {
+    optionalGenotypeFields.map { f =>
+      gStruct.indexWhere(SQLUtils.structFieldsEqualExceptNullability(f, _))
+    }
+  }
+
   protected lazy val genotypeStructSize: Int = {
-    val gStruct = genotypesExpr
-      .dataType
-      .asInstanceOf[ArrayType]
-      .elementType
-      .asInstanceOf[StructType]
     gStruct.length
   }
 

--- a/core/src/main/scala/io/projectglow/transformers/normalizevariants/VariantNormalizer.scala
+++ b/core/src/main/scala/io/projectglow/transformers/normalizevariants/VariantNormalizer.scala
@@ -178,8 +178,8 @@ private[projectglow] object VariantNormalizer extends GlowLogging {
    * normalizes a single VariantContext by checking some conditions and then calling realignAlleles
    *
    * @param vc
-   * @param refGenomePathString
-   * @return: normalized VariantContext
+   * @param refGenomeDataSource
+   * @return normalized VariantContext
    */
   private def normalizeVC(
       vc: VariantContext,


### PR DESCRIPTION
## What changes are proposed in this pull request?
 Now that https://github.com/apache/spark/pull/25666 has merged, it's more convenient and performant to return an array and filter by index. In addition, we can now generate sample qc stats when we don't have sample ids, which we expect to be the common case.


## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
