### PR TITLE
Add PyPi and Maven Central badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![CircleCI](https://circleci.com/gh/projectglow/glow.svg?style=svg&circle-token=7511f70b2c810a18e88b5c537b0410e82db8617d)](https://circleci.com/gh/projectglow/glow)
 [![Documentation
 Status](https://readthedocs.org/projects/glow/badge/?version=latest)](https://glow.readthedocs.io/en/latest/?badge=latest)
+[![PyPi](https://img.shields.io/pypi/v/glow.py.svg)](https://pypi.org/project/glow.py/)
+[![Maven Central](https://img.shields.io/maven-central/v/io.projectglow/glow_2.11.svg)](https://mvnrepository.com/artifact/io.projectglow)
 
 # Building and Testing
 This project is built using sbt: https://www.scala-sbt.org/1.0/docs/Setup.html


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add PyPi and Maven Central badges to README.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

<img width="502" alt="Screen Shot 2019-10-17 at 5 45 50 PM" src="https://user-images.githubusercontent.com/4754931/67025352-2e46cb00-f106-11e9-8ee3-dbcbc252943e.png">

