### PR TITLE
Exclude netlib libraries from GATK dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,9 @@ lazy val dependencies = Seq(
     .exclude("org.ojalgo", "ojalgo-commons-math3")
     .exclude("org.reflections", "reflections")
     .exclude("org.seqdoop", "hadoop-bam")
-    .exclude("org.xerial", "sqlite-jdbc"),
+    .exclude("org.xerial", "sqlite-jdbc")
+    .exclude("com.github.fommil.netlib", "*"),
+
   // Test dependencies
   "org.scalatest" %% "scalatest" % "3.0.3" % "test",
   "org.scalacheck" %% "scalacheck" % "1.12.5" % "test",


### PR DESCRIPTION
## What changes are proposed in this pull request?

In #37 @jpdna reported an error when using `spark-submit`'s maven resolver to install glow. This error occurs because the resolver doesn't seem to work with dependencies with a classifier.

I resolved the issue by excluding the native netlib libraries. Besides resolving this particular issue, this change follows the pattern established by mllib where users must explicitly opt into using the native extensions.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

Verified that `sbt dependencyTree` no longer contains any of the netlib native libraries.
