### PR TITLE
Function to aggregate across all elements at each index in array columns

### DIFF
--- a/core/src/main/scala/io/projectglow/sql/SqlExtensionProvider.scala
+++ b/core/src/main/scala/io/projectglow/sql/SqlExtensionProvider.scala
@@ -19,28 +19,31 @@ package io.projectglow.sql
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, UnresolvedExtractValue}
-import org.apache.spark.sql.catalyst.expressions.CreateNamedStruct
+import org.apache.spark.sql.catalyst.expressions.{CreateNamedStruct, LambdaFunction}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.internal.SQLConf
-
 import io.projectglow.common.VariantSchemas
 import io.projectglow.sql.expressions._
-import io.projectglow.sql.optimizer.HLSReplaceExpressionsRule
+import io.projectglow.sql.optimizer.{HLSReplaceExpressionsRule, ResolveAggregateFunctionsRule}
+
+// TODO(hhd): Spark 3.0 allows extensions to register functions. After Spark 3.0 is released,
+// we should move all extensions into this class.
+class GlowSQLExtensions extends (SparkSessionExtensions => Unit) {
+  val resolutionRules: Seq[Rule[LogicalPlan]] = Seq(ResolveAggregateFunctionsRule)
+  val optimizations: Seq[Rule[LogicalPlan]] = Seq(HLSReplaceExpressionsRule)
+  def apply(extensions: SparkSessionExtensions): Unit = {
+
+    resolutionRules.foreach(r => extensions.injectResolutionRule(_ => r))
+    optimizations.foreach(r => extensions.injectOptimizerRule(_ => r))
+  }
+}
 
 object SqlExtensionProvider {
 
   final def register(session: SparkSession): Unit = {
-    val experimental = session.experimental
-    experimental.extraOptimizations ++= getExtraOptimizations
-    experimental.extraStrategies ++= getExtraStrategies
     registerFunctions(session.sessionState.conf, session.sessionState.functionRegistry)
   }
-  def getExtraOptimizations: Seq[Rule[LogicalPlan]] = {
-    Seq(HLSReplaceExpressionsRule)
-  }
-
-  def getExtraStrategies: Seq[Strategy] = Nil
 
   def registerFunctions(conf: SQLConf, functionRegistry: FunctionRegistry): Unit = {
     functionRegistry.registerFunction(
@@ -145,6 +148,17 @@ object SqlExtensionProvider {
     functionRegistry.registerFunction(
       FunctionIdentifier("vector_to_array"),
       exprs => VectorToArray(exprs.head)
+    )
+
+    functionRegistry.registerFunction(
+      FunctionIdentifier("aggregate_by_index"),
+      exprs =>
+        UnwrappedAggregateByIndex(
+          exprs(0),
+          exprs(1),
+          exprs(2),
+          exprs(3),
+          exprs.lift(4).getOrElse(LambdaFunction.identity))
     )
   }
 }

--- a/core/src/main/scala/io/projectglow/sql/SqlExtensionProvider.scala
+++ b/core/src/main/scala/io/projectglow/sql/SqlExtensionProvider.scala
@@ -47,17 +47,19 @@ object SqlExtensionProvider {
 
   def registerFunctions(conf: SQLConf, functionRegistry: FunctionRegistry): Unit = {
     functionRegistry.registerFunction(
-      FunctionIdentifier("subset_struct"),
-      exprs => {
-        val struct = exprs.head
-        val fields = exprs.tail
-        CreateNamedStruct(fields.flatMap(f => Seq(f, UnresolvedExtractValue(struct, f))))
-      }
+      FunctionIdentifier("add_struct_fields"),
+      exprs => AddStructFields(exprs.head, exprs.tail)
     )
 
     functionRegistry.registerFunction(
-      FunctionIdentifier("add_struct_fields"),
-      exprs => AddStructFields(exprs.head, exprs.tail)
+      FunctionIdentifier("aggregate_by_index"),
+      exprs =>
+        UnwrappedAggregateByIndex(
+          exprs(0),
+          exprs(1),
+          exprs(2),
+          exprs(3),
+          exprs.lift(4).getOrElse(LambdaFunction.identity))
     )
 
     functionRegistry.registerFunction(
@@ -146,19 +148,17 @@ object SqlExtensionProvider {
     )
 
     functionRegistry.registerFunction(
-      FunctionIdentifier("vector_to_array"),
-      exprs => VectorToArray(exprs.head)
+      FunctionIdentifier("subset_struct"),
+      exprs => {
+        val struct = exprs.head
+        val fields = exprs.tail
+        CreateNamedStruct(fields.flatMap(f => Seq(f, UnresolvedExtractValue(struct, f))))
+      }
     )
 
     functionRegistry.registerFunction(
-      FunctionIdentifier("aggregate_by_index"),
-      exprs =>
-        UnwrappedAggregateByIndex(
-          exprs(0),
-          exprs(1),
-          exprs(2),
-          exprs(3),
-          exprs.lift(4).getOrElse(LambdaFunction.identity))
+      FunctionIdentifier("vector_to_array"),
+      exprs => VectorToArray(exprs.head)
     )
   }
 }

--- a/core/src/main/scala/io/projectglow/sql/expressions/AggregateByIndex.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/AggregateByIndex.scala
@@ -67,11 +67,9 @@ trait AggregateByIndex extends DeclarativeAggregate with HigherOrderFunction {
       newMerge: Expression,
       newEvaluate: Expression): AggregateByIndex
 
-
   protected val buffer: AttributeReference = {
     AttributeReference("buffer", ArrayType(initialValue.dataType))()
   }
-
 
   // Overrides from [[Expression]]
   override def prettyName: String = "aggregate_by_index"
@@ -100,7 +98,6 @@ trait AggregateByIndex extends DeclarativeAggregate with HigherOrderFunction {
     )
   }
 
-
   // Overrides from [[DeclarativeAggregate]]
   override def aggBufferAttributes: Seq[AttributeReference] = Seq(buffer)
 
@@ -126,7 +123,6 @@ trait AggregateByIndex extends DeclarativeAggregate with HigherOrderFunction {
   override lazy val mergeExpressions: Seq[Expression] = Seq(mergeExpr)
 
   override lazy val updateExpressions: Seq[Expression] = Seq(updateExpr)
-
 
   /**
    * A helper for accessing a buffer that may not yet be initialized.

--- a/core/src/main/scala/io/projectglow/sql/expressions/AggregateByIndex.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/AggregateByIndex.scala
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectglow.sql.expressions
+
+import org.apache.spark.sql.SQLUtils
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.expressions._
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, DeclarativeAggregate}
+import org.apache.spark.sql.types._
+
+/**
+ * An expression that allows users to aggregate over all array elements at a specific index in an
+ * array column. For example, this expression can be used to compute per-sample summary statistics
+ * from a genotypes column.
+ *
+ * The user must provide the following arguments:
+ * - The array for aggregation
+ * - The initialValue for each element in the per-index buffer
+ * - An update function to update the accumulator with a new element
+ * - A merge function to combine two accumulators
+ *
+ * The user may optionally provide an evaluate function. If it's not provided, the identity function
+ * is used.
+ *
+ * Example usage to calculate total depth across all sites for a sample:
+ * aggregate_by_index(
+ *   genotypes,
+ *   0,
+ *   (acc, genotype) -> acc + genotype.depth,
+ *   (acc1, acc2) -> acc1 + acc2,
+ *   acc -> acc)
+ */
+trait AggregateByIndex extends DeclarativeAggregate with HigherOrderFunction {
+
+  /** The array over which we're aggregating */
+  def arr: Expression
+
+  /** The initial value for each element in the aggregation buffer */
+  def initialValue: Expression
+
+  /** Function to update an element of the buffer with a new input element */
+  def update: Expression
+
+  /** Function to merge two buffers elements */
+  def merge: Expression
+
+  /** Function to turn a buffer into the actual output */
+  def evaluate: Expression
+
+  def withBoundExprs(
+      newUpdate: Expression,
+      newMerge: Expression,
+      newEvaluate: Expression): AggregateByIndex
+
+  protected val buffer: AttributeReference = {
+    AttributeReference("buffer", ArrayType(initialValue.dataType))()
+  }
+
+  /**
+   * Since we don't know the proper size of the aggregation buffer, we create it with the size
+   * of the data array (or the aggregation buffer with which it's being merged) if it's not yet
+   * defined.
+   */
+  private def bufferNotNull(buf: Expression, array: Expression): Expression = {
+    If(buf.isNull, ArrayRepeat(initialValue, Size(array)), buf)
+  }
+
+  override def prettyName: String = "aggregate_by_index"
+  override def nullable: Boolean = children.exists(_.nullable)
+  override def dataType: DataType = ArrayType(evaluate.dataType)
+  override def functions: Seq[Expression] = Seq(update, merge, evaluate)
+  override def functionTypes: Seq[SQLUtils.ADT] = {
+    Seq(SQLUtils.anyDataType, SQLUtils.anyDataType, SQLUtils.anyDataType)
+  }
+
+  override def arguments: Seq[Expression] = Seq(arr)
+  override def argumentTypes: Seq[SQLUtils.ADT] = Seq(arr.dataType)
+
+  /**
+   * To create bound lambda functions, we bind each of the child higher order functions,
+   * extract their bound lambda functions, and then copy.
+   */
+  override def bind(
+      f: (Expression, Seq[(DataType, Boolean)]) => LambdaFunction): AggregateByIndex = {
+    withBoundExprs(
+      updateExpr.bind(f).function,
+      mergeExpr.bind(f).function,
+      evaluateExpr.bind(f).function
+    )
+  }
+
+  override def aggBufferAttributes: Seq[AttributeReference] = Seq(buffer)
+
+  private lazy val updateExpr = {
+    ZipWith(bufferNotNull(buffer, arr), arr, update)
+  }
+
+  private lazy val mergeExpr = {
+    val leftBuffer = bufferNotNull(buffer.left, buffer.right)
+    val rightBuffer = bufferNotNull(buffer.right, buffer.left)
+
+    ZipWith(leftBuffer, rightBuffer, merge)
+  }
+
+  private lazy val evaluateExpr = ArrayTransform(buffer, evaluate)
+
+  override lazy val evaluateExpression: Expression = evaluateExpr
+
+  override lazy val initialValues: Seq[Expression] = {
+    Seq(Literal(null, ArrayType(initialValue.dataType)))
+  }
+
+  override lazy val mergeExpressions: Seq[Expression] = Seq(mergeExpr)
+
+  override lazy val updateExpressions: Seq[Expression] = Seq(updateExpr)
+}
+
+/**
+ * A hack to make Spark SQL recognize [[AggregateByIndex]] as an aggregate expression.
+ *
+ * See [[io.projectglow.sql.optimizer.ResolveAggregateFunctionsRule]] for details.
+ */
+trait UnwrappedAggregateFunction extends AggregateFunction {
+  def asWrapped: AggregateFunction
+}
+
+case class UnwrappedAggregateByIndex(
+    arr: Expression,
+    initialValue: Expression,
+    update: Expression,
+    merge: Expression,
+    evaluate: Expression)
+    extends AggregateByIndex
+    with UnwrappedAggregateFunction {
+
+  override def withBoundExprs(
+      newUpdate: Expression,
+      newMerge: Expression,
+      newEvaluate: Expression): AggregateByIndex = {
+
+    copy(update = newUpdate, merge = newMerge, evaluate = newEvaluate)
+  }
+
+  override def asWrapped: AggregateFunction = {
+    WrappedAggregateByIndex(arr, initialValue, update, merge, evaluate)
+  }
+}
+
+case class WrappedAggregateByIndex(
+    arr: Expression,
+    initialValue: Expression,
+    update: Expression,
+    merge: Expression,
+    evaluate: Expression)
+    extends AggregateByIndex {
+
+  override def withBoundExprs(
+      newUpdate: Expression,
+      newMerge: Expression,
+      newEvaluate: Expression): AggregateByIndex = {
+
+    copy(update = newUpdate, merge = newMerge, evaluate = newEvaluate)
+  }
+}

--- a/core/src/main/scala/io/projectglow/sql/optimizer/hlsOptimizerRules.scala
+++ b/core/src/main/scala/io/projectglow/sql/optimizer/hlsOptimizerRules.scala
@@ -16,13 +16,13 @@
 
 package io.projectglow.sql.optimizer
 
-import io.projectglow.sql.expressions.{AddStructFields, AggregateByIndex, UnwrappedAggregateFunction}
-
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Complete}
 import org.apache.spark.sql.catalyst.expressions.{CreateNamedStruct, GetStructField, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.types.StructType
+
+import io.projectglow.sql.expressions.{AddStructFields, AggregateByIndex, UnwrappedAggregateFunction}
 
 /**
  * Simple optimization rule that handles expression rewrites

--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -42,10 +42,9 @@ import org.broadinstitute.hellbender.tools.walkers.genotyper.GenotypeAssignmentM
 import org.broadinstitute.hellbender.utils.SimpleInterval
 import org.broadinstitute.hellbender.utils.variant.GATKVariantContextUtils
 import org.seqdoop.hadoop_bam.util.{BGZFEnhancedGzipCodec, DatabricksBGZFOutputStream}
-
 import io.projectglow.common.logging.{HlsMetricDefinitions, HlsTagDefinitions, HlsTagValues, HlsUsageLogging}
 import io.projectglow.common.{GlowLogging, VCFRow, WithUtils}
-import io.projectglow.sql.util.{ComDatabricksDataSource, HadoopLineIterator, SerializableConfiguration}
+import io.projectglow.sql.util.{BGZFCodec, ComDatabricksDataSource, HadoopLineIterator, SerializableConfiguration}
 
 class VCFFileFormat extends TextBasedFileFormat with DataSourceRegister with HlsUsageLogging {
   var codecFactory: CompressionCodecFactory = _
@@ -248,8 +247,8 @@ object VCFFileFormat {
   def hadoopConfWithBGZ(conf: Configuration): Configuration = {
     val toReturn = new Configuration(conf)
     val bgzCodecs = Seq(
-      "io.projectglow.sql.util.BGZFCodec",
-      "org.seqdoop.hadoop_bam.util.BGZFEnhancedGzipCodec"
+      classOf[BGZFCodec].getCanonicalName,
+      classOf[BGZFEnhancedGzipCodec].getCanonicalName
     )
     val codecs = toReturn
         .get("io.compression.codecs", "")

--- a/core/src/main/scala/org/apache/spark/sql/SQLUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SQLUtils.scala
@@ -20,6 +20,9 @@ import org.apache.spark.TaskContext
 import org.apache.spark.ml.linalg.{MatrixUDT, VectorUDT}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.types._
 
 object SQLUtils {
@@ -71,6 +74,8 @@ object SQLUtils {
   def newAnalysisException(msg: String): AnalysisException = {
     new AnalysisException(msg)
   }
+
+  def anyDataType: ADT = AnyDataType
 
   type ADT = AbstractDataType
 }

--- a/core/src/main/scala/org/apache/spark/sql/SQLUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SQLUtils.scala
@@ -20,9 +20,6 @@ import org.apache.spark.TaskContext
 import org.apache.spark.ml.linalg.{MatrixUDT, VectorUDT}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.types._
 
 object SQLUtils {

--- a/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
+++ b/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
@@ -23,8 +23,8 @@ import org.apache.spark.{DebugFilesystem, SparkConf}
 import org.scalatest.concurrent.{AbstractPatienceConfiguration, Eventually}
 import org.scalatest.time.{Milliseconds, Seconds, Span}
 import org.scalatest.{Args, FunSuite, Status, Tag}
-
 import io.projectglow.common.{GlowLogging, TestUtils}
+import io.projectglow.sql.util.BGZFCodec
 
 abstract class GlowBaseTest
     extends FunSuite
@@ -42,8 +42,7 @@ abstract class GlowBaseTest
       .set("spark.kryoserializer.buffer.max", "2047m")
       .set("spark.kryo.registrationRequired", "false")
       .set(
-        "spark.hadoop.io.compression.codecs",
-        "org.seqdoop.hadoop_bam.util.BGZFCodec,org.seqdoop.hadoop_bam.util.BGZFEnhancedGzipCodec"
+        "spark.hadoop.io.compression.codecs", classOf[BGZFCodec].getCanonicalName
       )
       .set("spark.sql.extensions", classOf[GlowSQLExtensions].getCanonicalName)
 

--- a/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
+++ b/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
@@ -42,7 +42,8 @@ abstract class GlowBaseTest
       .set("spark.kryoserializer.buffer.max", "2047m")
       .set("spark.kryo.registrationRequired", "false")
       .set(
-        "spark.hadoop.io.compression.codecs", classOf[BGZFCodec].getCanonicalName
+        "spark.hadoop.io.compression.codecs",
+        classOf[BGZFCodec].getCanonicalName
       )
       .set("spark.sql.extensions", classOf[GlowSQLExtensions].getCanonicalName)
 

--- a/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
+++ b/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
@@ -45,15 +45,18 @@ abstract class GlowBaseTest
         "spark.hadoop.io.compression.codecs",
         "org.seqdoop.hadoop_bam.util.BGZFCodec,org.seqdoop.hadoop_bam.util.BGZFEnhancedGzipCodec"
       )
+      .set("spark.sql.extensions", classOf[GlowSQLExtensions].getCanonicalName)
 
   }
 
-  override protected def createSparkSession = {
-    val session = super.createSparkSession
-    SqlExtensionProvider.register(session)
-    SparkSession.setActiveSession(session)
+  override def initializeSession(): Unit = ()
+
+  override protected implicit def spark: SparkSession = {
+    val sess = SparkSession.builder().config(sparkConf).master("local[2]").getOrCreate()
+    SqlExtensionProvider.register(sess)
+    SparkSession.setActiveSession(sess)
     Log.setGlobalLogLevel(Log.LogLevel.ERROR)
-    session
+    sess
   }
 
   protected def gridTest[A](testNamePrefix: String, testTags: Tag*)(params: Seq[A])(

--- a/core/src/test/scala/io/projectglow/tertiary/AggregateByIndexSuite.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/AggregateByIndexSuite.scala
@@ -124,4 +124,36 @@ class AggregateByIndexSuite extends GlowBaseTest {
       assert(row == Seq(0, 10, 20, 30, 40))
     }
   }
+
+  test("empty dataframe") {
+    import sess.implicits._
+    val result = spark
+      .emptyDataset[Tuple1[Seq[Int]]]
+      .selectExpr("""
+          |aggregate_by_index(
+          |_1,
+          |0,
+          |(acc, el) -> acc + el,
+          |(acc1, acc2) -> acc1 + acc2)
+        """.stripMargin)
+      .as[Seq[Int]]
+      .head
+    assert(result == Seq.empty)
+  }
+
+  test("null array") {
+    import sess.implicits._
+    val result = spark
+      .createDataFrame(Seq(Tuple1(null), Tuple1(Seq(1))))
+      .selectExpr("""
+          |aggregate_by_index(
+          |_1,
+          |0,
+          |(acc, el) -> acc + el,
+          |(acc1, acc2) -> acc1 + acc2)
+        """.stripMargin)
+      .as[Seq[Option[Int]]]
+      .head
+    assert(result == Seq(None))
+  }
 }

--- a/core/src/test/scala/io/projectglow/tertiary/AggregateByIndexSuite.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/AggregateByIndexSuite.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectglow.tertiary
+
+import org.apache.spark.sql.functions._
+import io.projectglow.sql.GlowBaseTest
+import org.apache.spark.sql.AnalysisException
+
+class AggregateByIndexSuite extends GlowBaseTest {
+  private lazy val sess = spark
+
+  test("basic") {
+    import sess.implicits._
+    val results = spark
+      .createDataFrame(Seq(Tuple1(Seq(1L, 2L, 3L))))
+      .selectExpr("aggregate_by_index(_1, 0l, (x, y) -> x + y, (x, y) -> x + y, x -> x) as agg")
+      .as[Seq[Long]]
+      .head
+    assert(results == Seq(1L, 2L, 3L))
+  }
+
+  test("with types changes") {
+    import sess.implicits._
+    val results = spark
+      .createDataFrame(Seq(Tuple1(Seq(1L, 2L, 3L))))
+      .selectExpr("""
+          |aggregate_by_index(
+          |_1,
+          |0d,
+          |(x, y) -> cast(x as double) + cast(y as double),
+          |(x, y) -> x + y,
+          |x -> cast(x as string))
+        """.stripMargin)
+      .as[Seq[String]]
+      .head
+    assert(results == Seq("1.0", "2.0", "3.0"))
+  }
+
+  test("with grouping") {
+    import sess.implicits._
+    val df = spark.createDataFrame(
+      Seq(
+        ("a", Seq(1, 2, 3)),
+        ("b", Seq(4, 5, 6))
+      ))
+    val results = df
+      .groupBy("_1")
+      .agg(expr("aggregate_by_index(_2, 0, (x, y) -> x + y, (x, y) -> x + y, x -> x)"))
+      .orderBy("_1")
+      .as[(String, Seq[Int])]
+      .collect
+      .toSeq
+    assert(results == Seq(("a", Seq(1, 2, 3)), ("b", Seq(4, 5, 6))))
+  }
+
+  test("mean function") {
+    import sess.implicits._
+
+    val result = spark
+      .range(10000)
+      .withColumn("values", array_repeat(col("id"), 100))
+      .selectExpr(
+        """
+          |aggregate_by_index(
+          |values,
+          |struct(0l, 0l),
+          |(state, el) -> struct(state.col1 + 1, state.col2 + el),
+          |(state1, state2) -> struct(state1.col1 + state2.col1, state1.col2 + state2.col2),
+          |state -> if(state.col1 = 0, null, state.col2 / state.col1))
+        """.stripMargin
+      )
+      .as[Seq[Double]]
+      .head
+    assert(result == Seq.fill(100)(4999.5d))
+
+  }
+
+  test("type error") {
+    intercept[AnalysisException] {
+      spark
+        .range(10000)
+        .withColumn("values", array_repeat(col("id"), 100))
+        .selectExpr("""
+            |aggregate_by_index(
+            |values,
+            |1,
+            |(acc, el) -> size(acc), -- type error since size expects a map or array
+            |(acc1, acc2) -> acc1 + acc2)
+          """.stripMargin)
+        .collect()
+    }
+  }
+
+  test("no evaluate function") {
+    import sess.implicits._
+    val results = spark
+      .range(10)
+      .withColumn("values", expr("transform(array_repeat(0, 5), (el, idx) -> idx)"))
+      .selectExpr("""
+          |aggregate_by_index(
+          |values,
+          |0,
+          |(acc, el) -> acc + el,
+          |(acc1, acc2) -> acc1 + acc2)
+        """.stripMargin)
+      .as[Seq[Int]]
+      .collect
+      .toSeq
+    results.foreach { row =>
+      assert(row == Seq(0, 10, 20, 30, 40))
+    }
+  }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

We currently include a few functions to compute sample-based quality control statistics. However, users can't write their own functions that aggregate across the same dimension without getting intimately familiar with Spark internals.

This PR adds a function,  `aggregate_by_index`, that provides the scaffolding for users to write their own aggregations. The user provides an initial value, an update function to merge a buffer object with a new datum, a merge function to combine two buffers, and optionally an evaluate function called on the buffer to produce a result. These arguments are analogous to those of the `aggregate` higher order function built into Spark: https://docs.databricks.com/_static/notebooks/apache-spark-2.4-functions.html.

I'll provide documentation for the new function as well as the initialization changes in a separate PR. 

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
