### PR TITLE
Replace df.show() with df.collect()

### DIFF
--- a/core/src/test/scala/io/projectglow/tertiary/VariantQcExprsSuite.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/VariantQcExprsSuite.scala
@@ -41,7 +41,7 @@ class VariantQcExprsSuite extends GlowBaseTest {
       .filter(targetSite)
       .selectExpr("explode(genotypes)")
       .selectExpr("expand_struct(col)")
-      .show()
+      .collect()
   }
 
   // Golden values are pulled from Hail

--- a/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
@@ -107,8 +107,8 @@ abstract class VCFFileWriterSuite(val sourceName: String)
 
   gridTest("Read single sample VCF with VCF parser")(schemaOptions) { schema =>
     val (ds, rewrittenDs) = writeAndRereadWithDBParser(NA12878, schemaOption = schema)
-    ds.show()
-    rewrittenDs.show()
+    ds.collect()
+    rewrittenDs.collect()
     ds.collect.zip(rewrittenDs.collect).foreach {
       case (vc1, vc2) =>
         assert(vc1.equals(vc2), s"VC1\n$vc1\nVC2\n$vc2")


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

Sometimes in tests we use `show()` to force materialization of a dataframe. This pattern makes the test logs really noisy. Instead, we can just call `.collect()` to force materialization.

## What changes are proposed in this pull request?
(Details)

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

Test logs should be clean now.