### PR TITLE
Add BGEN option to explicitly not include sample ids

### DIFF
--- a/core/src/main/scala/io/projectglow/bgen/BgenFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/bgen/BgenFileFormat.scala
@@ -36,9 +36,8 @@ import org.skife.jdbi.v2.DBI
 import org.skife.jdbi.v2.util.LongMapper
 
 import io.projectglow.common.logging.{HlsMetricDefinitions, HlsTagDefinitions, HlsTagValues, HlsUsageLogging}
-import io.projectglow.common.{GlowLogging, WithUtils}
+import io.projectglow.common.{BgenOptions, GlowLogging, WithUtils}
 import io.projectglow.sql.util.{ComDatabricksDataSource, SerializableConfiguration}
-import io.projectglow.vcf.VCFOption
 
 class BgenFileFormat extends FileFormat with DataSourceRegister with Serializable with GlowLogging {
 
@@ -77,8 +76,8 @@ class BgenFileFormat extends FileFormat with DataSourceRegister with Serializabl
       options: Map[String, String],
       hadoopConf: Configuration): PartitionedFile => Iterator[InternalRow] = {
 
-    val useIndex = options.get(BgenFileFormat.USE_INDEX_KEY).forall(_.toBoolean)
-    val ignoreExtension = options.get(BgenFileFormat.IGNORE_EXTENSION_KEY).exists(_.toBoolean)
+    val useIndex = options.get(BgenOptions.USE_INDEX_KEY).forall(_.toBoolean)
+    val ignoreExtension = options.get(BgenOptions.IGNORE_EXTENSION_KEY).exists(_.toBoolean)
     val sampleIdsOpt = BgenFileFormat.getSampleIds(options, hadoopConf)
 
     // record bgenRead event in the log along with the option
@@ -175,6 +174,8 @@ class BgenFileFormat extends FileFormat with DataSourceRegister with Serializabl
 class ComDatabricksBgenFileFormat extends BgenFileFormat with ComDatabricksDataSource
 
 object BgenFileFormat extends HlsUsageLogging {
+  import io.projectglow.common.BgenOptions._
+
   val BGEN_SUFFIX = ".bgen"
   val INDEX_SUFFIX = ".bgi"
   val NEXT_IDX_QUERY =
@@ -183,11 +184,6 @@ object BgenFileFormat extends HlsUsageLogging {
       |WHERE file_start_position > :pos
     """.stripMargin
   val idxLock = Striped.lock(100)
-  val IGNORE_EXTENSION_KEY = "ignoreExtension"
-  val USE_INDEX_KEY = "useBgenIndex"
-  val SAMPLE_FILE_PATH_OPTION_KEY = "sampleFilePath"
-  val SAMPLE_ID_COLUMN_OPTION_KEY = "sampleIdColumn"
-  val SAMPLE_ID_COLUMN_OPTION_DEFAULT_VALUE = "ID_2"
 
   /**
    * Given a path to an Oxford-style .sample file exists (option: sampleFilePath), reads the sample
@@ -245,7 +241,7 @@ object BgenFileFormat extends HlsUsageLogging {
   def logBgenRead(options: Map[String, String]): Unit = {
 
     val logOptions = Map(
-      USE_INDEX_KEY -> options.get(BgenFileFormat.USE_INDEX_KEY).forall(_.toBoolean)
+      USE_INDEX_KEY -> options.get(USE_INDEX_KEY).forall(_.toBoolean)
     )
     recordHlsUsage(
       HlsMetricDefinitions.EVENT_HLS_USAGE,

--- a/core/src/main/scala/io/projectglow/bgen/BgenFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/bgen/BgenFileFormat.scala
@@ -38,6 +38,7 @@ import org.skife.jdbi.v2.util.LongMapper
 import io.projectglow.common.logging.{HlsMetricDefinitions, HlsTagDefinitions, HlsTagValues, HlsUsageLogging}
 import io.projectglow.common.{GlowLogging, WithUtils}
 import io.projectglow.sql.util.{ComDatabricksDataSource, SerializableConfiguration}
+import io.projectglow.vcf.VCFOption
 
 class BgenFileFormat extends FileFormat with DataSourceRegister with Serializable with GlowLogging {
 
@@ -197,7 +198,6 @@ object BgenFileFormat extends HlsUsageLogging {
    * If no path is given, None is returned; if a valid path is given, Some list is returned.
    */
   def getSampleIds(options: Map[String, String], hadoopConf: Configuration): Option[Seq[String]] = {
-
     val samplePathOpt = options.get(SAMPLE_FILE_PATH_OPTION_KEY)
 
     if (samplePathOpt.isEmpty) {

--- a/core/src/main/scala/io/projectglow/bgen/BgenSchemaInferrer.scala
+++ b/core/src/main/scala/io/projectglow/bgen/BgenSchemaInferrer.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.types.StructType
 
 import io.projectglow.common.{VariantSchemas, WithUtils}
 import io.projectglow.sql.util.SerializableConfiguration
+import io.projectglow.vcf.VCFOption
 
 /**
  * Infers the schema of a set of BGEN files from the user-provided options and the header of each
@@ -37,6 +38,11 @@ object BgenSchemaInferrer {
       spark: SparkSession,
       files: Seq[FileStatus],
       options: Map[String, String]): StructType = {
+    val shouldIncludeSampleIds = options.get(VCFOption.INCLUDE_SAMPLE_IDS).forall(_.toBoolean)
+    if (!shouldIncludeSampleIds) {
+      return VariantSchemas.bgenDefaultSchema(hasSampleIds = false)
+    }
+
     val sampleIdsFromSampleFile =
       BgenFileFormat.getSampleIds(options, spark.sparkContext.hadoopConfiguration)
     if (sampleIdsFromSampleFile.isDefined) {

--- a/core/src/main/scala/io/projectglow/bgen/BgenSchemaInferrer.scala
+++ b/core/src/main/scala/io/projectglow/bgen/BgenSchemaInferrer.scala
@@ -21,9 +21,8 @@ import org.apache.hadoop.fs.{FileStatus, Path}
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.StructType
 
-import io.projectglow.common.{VariantSchemas, WithUtils}
+import io.projectglow.common.{BgenOptions, CommonOptions, VariantSchemas, WithUtils}
 import io.projectglow.sql.util.SerializableConfiguration
-import io.projectglow.vcf.VCFOption
 
 /**
  * Infers the schema of a set of BGEN files from the user-provided options and the header of each
@@ -38,7 +37,7 @@ object BgenSchemaInferrer {
       spark: SparkSession,
       files: Seq[FileStatus],
       options: Map[String, String]): StructType = {
-    val shouldIncludeSampleIds = options.get(VCFOption.INCLUDE_SAMPLE_IDS).forall(_.toBoolean)
+    val shouldIncludeSampleIds = options.get(CommonOptions.INCLUDE_SAMPLE_IDS).forall(_.toBoolean)
     if (!shouldIncludeSampleIds) {
       return VariantSchemas.bgenDefaultSchema(hasSampleIds = false)
     }
@@ -50,7 +49,7 @@ object BgenSchemaInferrer {
     }
 
     val serializableConf = new SerializableConfiguration(spark.sparkContext.hadoopConfiguration)
-    val ignoreExtension = options.get(BgenFileFormat.IGNORE_EXTENSION_KEY).exists(_.toBoolean)
+    val ignoreExtension = options.get(BgenOptions.IGNORE_EXTENSION_KEY).exists(_.toBoolean)
     val bgenPaths =
       files.filter { fs =>
         fs.getLen > 0 && (fs

--- a/core/src/main/scala/io/projectglow/common/datasourceOptions.scala
+++ b/core/src/main/scala/io/projectglow/common/datasourceOptions.scala
@@ -1,0 +1,39 @@
+package io.projectglow.common
+
+object CommonOptions {
+  val INCLUDE_SAMPLE_IDS = "includeSampleIds"
+}
+
+object VCFOptions {
+  // Reader-only options
+  val FLATTEN_INFO_FIELDS = "flattenInfoFields"
+  val SPLIT_TO_BIALLELIC = "splitToBiallelic"
+  val VCF_ROW_SCHEMA = "vcfRowSchema"
+  val USE_TABIX_INDEX = "useTabixIndex"
+  val USE_FILTER_PARSER = "useFilterParser"
+
+  // Writer-only options
+  val COMPRESSION = "compression"
+
+  // Reader and writer options
+  val VALIDATION_STRINGENCY = "validationStringency"
+}
+
+object BgenOptions {
+  val IGNORE_EXTENSION_KEY = "ignoreExtension"
+  val USE_INDEX_KEY = "useBgenIndex"
+  val SAMPLE_FILE_PATH_OPTION_KEY = "sampleFilePath"
+  val SAMPLE_ID_COLUMN_OPTION_KEY = "sampleIdColumn"
+  val SAMPLE_ID_COLUMN_OPTION_DEFAULT_VALUE = "ID_2"
+}
+
+object PlinkOptions {
+  // Delimiter options
+  val FAM_DELIMITER_KEY = "famDelimiter"
+  val BIM_DELIMITER_KEY = "bimDelimiter"
+  val DEFAULT_FAM_DELIMITER_VALUE = " "
+  val DEFAULT_BIM_DELIMITER_VALUE = "\t"
+
+  // Sample ID options
+  val MERGE_FID_IID = "mergeFidIid"
+}

--- a/core/src/main/scala/io/projectglow/common/datasourceOptions.scala
+++ b/core/src/main/scala/io/projectglow/common/datasourceOptions.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectglow.common
 
 object CommonOptions {

--- a/core/src/main/scala/io/projectglow/plink/PlinkFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/plink/PlinkFileFormat.scala
@@ -17,6 +17,7 @@
 package io.projectglow.plink
 
 import scala.collection.JavaConverters._
+
 import com.google.common.io.LittleEndianDataInputStream
 import com.univocity.parsers.csv.CsvParser
 import org.apache.commons.io.IOUtils
@@ -35,10 +36,9 @@ import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.{StructField, StructType}
 
-import io.projectglow.common.{GlowLogging, VariantSchemas}
+import io.projectglow.common.{CommonOptions, GlowLogging, VCFOptions, VariantSchemas}
 import io.projectglow.common.logging.{HlsMetricDefinitions, HlsTagDefinitions, HlsTagValues, HlsUsageLogging}
 import io.projectglow.sql.util.SerializableConfiguration
-import io.projectglow.vcf.VCFOption
 
 class PlinkFileFormat
     extends FileFormat
@@ -54,7 +54,7 @@ class PlinkFileFormat
       sparkSession: SparkSession,
       options: Map[String, String],
       files: Seq[FileStatus]): Option[StructType] = {
-    val includeSampleIds = options.get(VCFOption.INCLUDE_SAMPLE_IDS).forall(_.toBoolean)
+    val includeSampleIds = options.get(CommonOptions.INCLUDE_SAMPLE_IDS).forall(_.toBoolean)
     Some(VariantSchemas.plinkSchema(includeSampleIds))
   }
 
@@ -137,19 +137,11 @@ class PlinkFileFormat
 object PlinkFileFormat extends HlsUsageLogging {
 
   import io.projectglow.common.VariantSchemas._
-
-  // Delimiter options
-  val FAM_DELIMITER_KEY = "famDelimiter"
-  val BIM_DELIMITER_KEY = "bimDelimiter"
-  val DEFAULT_FAM_DELIMITER_VALUE = " "
-  val DEFAULT_BIM_DELIMITER_VALUE = "\t"
-  val CSV_DELIMITER_KEY = "delimiter"
-
-  // Sample ID options
-  val MERGE_FID_IID = "mergeFidIid"
+  import io.projectglow.common.PlinkOptions._
 
   val FAM_FILE_EXTENSION = ".fam"
   val BIM_FILE_EXTENSION = ".bim"
+  val CSV_DELIMITER_KEY = "delimiter"
 
   val BLOCKS_PER_BYTE = 4
   val MAGIC_BYTES: Seq[Byte] = Seq(0x6c, 0x1b, 0x01).map(_.toByte)

--- a/core/src/test/scala/io/projectglow/bgen/BgenReaderSuite.scala
+++ b/core/src/test/scala/io/projectglow/bgen/BgenReaderSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.types.{ArrayType, StructType}
 
 import io.projectglow.common.{BgenRow, VCFRow, VariantSchemas}
 import io.projectglow.sql.GlowBaseTest
+import io.projectglow.vcf.VCFOption
 
 class BgenReaderSuite extends GlowBaseTest {
 
@@ -392,5 +393,14 @@ class BgenReaderSuite extends GlowBaseTest {
       .format(sourceName)
       .load(s"$testRoot/example.16bits.nosampleids.bgen")
     assert(hasSampleIdField(df.schema))
+  }
+
+  test("schema does not include sample ids if `includeSampleIds` is false") {
+    val df = spark
+      .read
+      .format(sourceName)
+      .option(VCFOption.INCLUDE_SAMPLE_IDS, false)
+      .load(s"$testRoot/example.16bits*.bgen")
+    assert(!hasSampleIdField(df.schema))
   }
 }

--- a/core/src/test/scala/io/projectglow/bgen/BgenReaderSuite.scala
+++ b/core/src/test/scala/io/projectglow/bgen/BgenReaderSuite.scala
@@ -26,9 +26,8 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.catalyst.ScalaReflection
 import org.apache.spark.sql.types.{ArrayType, StructType}
 
-import io.projectglow.common.{BgenRow, VCFRow, VariantSchemas}
+import io.projectglow.common._
 import io.projectglow.sql.GlowBaseTest
-import io.projectglow.vcf.VCFOption
 
 class BgenReaderSuite extends GlowBaseTest {
 
@@ -351,7 +350,7 @@ class BgenReaderSuite extends GlowBaseTest {
       spark
         .read
         .format(sourceName)
-        .option(BgenFileFormat.IGNORE_EXTENSION_KEY, true)
+        .option(BgenOptions.IGNORE_EXTENSION_KEY, true)
         .load(input)
         .count()
     }
@@ -399,7 +398,7 @@ class BgenReaderSuite extends GlowBaseTest {
     val df = spark
       .read
       .format(sourceName)
-      .option(VCFOption.INCLUDE_SAMPLE_IDS, false)
+      .option(CommonOptions.INCLUDE_SAMPLE_IDS, false)
       .load(s"$testRoot/example.16bits*.bgen")
     assert(!hasSampleIdField(df.schema))
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, if a BGEN file contained sampleIds, they were always included in the emitted DataFrame. If a user didn't want them (common when dealing with large cohort sizes), they had to manually drop them.

Now, you can provide the same `includeSampleIds` option used by the VCF and Plink datasources. If it is `false`, sample ids are not included in the output.

cc @emaxwell 

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
