### PR TITLE
Don't linkcheck for databricks.com

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -225,4 +225,9 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
-#
+# -- Linkcheck options -------------------------------------------------------
+
+linkcheck_ignore = [
+    # Currently experiencing server issues
+    r'https://databricks.com*',
+]


### PR DESCRIPTION
## What changes are proposed in this pull request?

The Databricks site is experiencing some server issues. To un-break the build, we can just ignore linkchecking there for now.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

`make linkcheck` works again!
