### PR TITLE
Cleaner error messaging if pipe input/output formatter not provided

### DIFF
--- a/core/src/main/scala/io/projectglow/transformers/pipe/PipeTransformer.scala
+++ b/core/src/main/scala/io/projectglow/transformers/pipe/PipeTransformer.scala
@@ -44,35 +44,35 @@ class PipeTransformer extends DataFrameTransformer with HlsUsageLogging {
     import PipeTransformer._
 
     private def getInputFormatter: InputFormatter = {
-      val inputFormatterStr = options.get(INPUT_FORMATTER_KEY)
+      val inputFormatterStr = options.getOrElse(
+        INPUT_FORMATTER_KEY,
+        throw new IllegalArgumentException("Missing pipe input formatter."))
+
       val inputFormatterOptions = options.collect {
         case (k, v) if k.startsWith(INPUT_FORMATTER_PREFIX) =>
           (k.stripPrefix(INPUT_FORMATTER_PREFIX), v)
       }
 
-      inputFormatterStr
-        .flatMap(lookupInputFormatterFactory)
-        .getOrElse {
-          throw new IllegalArgumentException(
-            s"Could not find an input formatter for $inputFormatterStr")
-        }
-        .makeInputFormatter(df, new SnakeCaseMap(inputFormatterOptions))
+      lookupInputFormatterFactory(inputFormatterStr).getOrElse {
+        throw new IllegalArgumentException(
+          s"Could not find an input formatter for $inputFormatterStr")
+      }.makeInputFormatter(df, new SnakeCaseMap(inputFormatterOptions))
     }
 
     private def getOutputFormatter: OutputFormatter = {
-      val outputFormatterStr = options.get(OUTPUT_FORMATTER_KEY)
+      val outputFormatterStr = options.getOrElse(
+        OUTPUT_FORMATTER_KEY,
+        throw new IllegalArgumentException("Missing pipe output formatter."))
+
       val outputFormatterOptions = options.collect {
         case (k, v) if k.startsWith(OUTPUT_FORMATTER_PREFIX) =>
           (k.stripPrefix(OUTPUT_FORMATTER_PREFIX), v)
       }
 
-      outputFormatterStr
-        .flatMap(lookupOutputFormatterFactory)
-        .getOrElse {
-          throw new IllegalArgumentException(
-            s"Could not find an output formatter for $outputFormatterStr")
-        }
-        .makeOutputFormatter(new SnakeCaseMap(outputFormatterOptions))
+      lookupOutputFormatterFactory(outputFormatterStr).getOrElse {
+        throw new IllegalArgumentException(
+          s"Could not find an output formatter for $outputFormatterStr")
+      }.makeOutputFormatter(new SnakeCaseMap(outputFormatterOptions))
     }
 
     private def getCmd: Seq[String] = {

--- a/core/src/test/scala/io/projectglow/transformers/pipe/PipeTransformerSuite.scala
+++ b/core/src/test/scala/io/projectglow/transformers/pipe/PipeTransformerSuite.scala
@@ -81,6 +81,26 @@ class PipeTransformerSuite extends GlowBaseTest {
     }
     assert(e.getMessage.contains("Missing pipe output formatter"))
   }
+
+  test("could not find input formatter") {
+    val df = spark.emptyDataFrame
+    val options =
+      Map("inputFormatter" -> "fake_in", "outputFormatter" -> "dummy_out", "cmd" -> """["cat"]""")
+    val e = intercept[IllegalArgumentException] {
+      new PipeTransformer().transform(df, options)
+    }
+    assert(e.getMessage.contains("Could not find an input formatter for fake_in"))
+  }
+
+  test("could not find output formatter") {
+    val df = spark.emptyDataFrame
+    val options =
+      Map("inputFormatter" -> "dummy_in", "outputFormatter" -> "fake_out", "cmd" -> """["cat"]""")
+    val e = intercept[IllegalArgumentException] {
+      new PipeTransformer().transform(df, options)
+    }
+    assert(e.getMessage.contains("Could not find an output formatter for fake_out"))
+  }
 }
 
 class DummyInputFormatterFactory() extends InputFormatterFactory {

--- a/core/src/test/scala/io/projectglow/transformers/pipe/PipeTransformerSuite.scala
+++ b/core/src/test/scala/io/projectglow/transformers/pipe/PipeTransformerSuite.scala
@@ -61,6 +61,26 @@ class PipeTransformerSuite extends GlowBaseTest {
 
     Glow.transform("pipe_cleanup", df, Map.empty[String, String])
   }
+
+  test("missing input formatter") {
+    val df = spark.emptyDataFrame
+    val options =
+      Map("outputFormatter" -> "dummy_out", "cmd" -> """["cat"]""")
+    val e = intercept[IllegalArgumentException] {
+      new PipeTransformer().transform(df, options)
+    }
+    assert(e.getMessage.contains("Missing pipe input formatter"))
+  }
+
+  test("missing output formatter") {
+    val df = spark.emptyDataFrame
+    val options =
+      Map("inputFormatter" -> "dummy_in", "cmd" -> """["cat"]""")
+    val e = intercept[IllegalArgumentException] {
+      new PipeTransformer().transform(df, options)
+    }
+    assert(e.getMessage.contains("Missing pipe output formatter"))
+  }
 }
 
 class DummyInputFormatterFactory() extends InputFormatterFactory {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Throws clearer exceptions if the pipe input or output formatter are not provided.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
