### PR TITLE
Depend on slf4j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,7 +73,7 @@ lazy val dependencies = Seq(
   "org.slf4j" % "slf4j-api" % "1.7.25",
   "org.slf4j" % "slf4j-log4j12" % "1.7.25",
   "org.jdbi" % "jdbi" % "2.63.1",
-  "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
+  "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2",
   // Exclude extraneous GATK dependencies
   ("org.broadinstitute" % "gatk" % "4.0.11.0")
     .exclude("biz.k11i", "xgboost-predictor")

--- a/core/src/main/scala/io/projectglow/common/GlowLogging.scala
+++ b/core/src/main/scala/io/projectglow/common/GlowLogging.scala
@@ -16,6 +16,6 @@
 
 package io.projectglow.common
 
-import com.typesafe.scalalogging.LazyLogging
+import com.typesafe.scalalogging.slf4j.LazyLogging
 
 trait GlowLogging extends LazyLogging


### PR DESCRIPTION
## What changes are proposed in this pull request?

During my changes in https://github.com/projectglow/glow/pull/68, I depended on a different subpackage of the Scala logger in anticipation of cross-building with Scala 2.12. We did not cross-build but the Scala logger subpackage change was not reverted; this PR reverts that.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests
