### PR TITLE
Fix for bigvcf writer with a header but no rows

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -48,25 +48,23 @@ object BigVCFDatasource extends HlsUsageLogging {
 
     val nParts = rdd.getNumPartitions
 
+    if (nParts == 0) {
+      throw new SparkException(
+        "Cannot write vcf because the DataFrame has zero partitions. " +
+        "Repartition to a positive number of partitions if you want to just write the header")
+    }
+
     val conf = VCFFileFormat.hadoopConfWithBGZ(data.sparkSession.sparkContext.hadoopConfiguration)
     val serializableConf = new SerializableConfiguration(conf)
     val firstNonemptyPartition =
       rdd.mapPartitions(iter => Iterator(iter.nonEmpty)).collect.indexOf(true)
 
-    if (firstNonemptyPartition == -1) {
-      if (!options.contains(VCFFileWriter.VCF_HEADER_KEY) ||
-        options
-          .get(VCFFileWriter.VCF_HEADER_KEY)
-          .contains(VCFFileWriter.INFER_HEADER)) {
-        throw new SparkException("Cannot infer header for empty VCF.")
-      }
-      if (nParts == 0) {
-        throw new SparkException(
-          "Cannot write vcf because the DataFrame has zero partitions. " +
-          "Repartition to a positive number of partitions if you want to just write the header")
-      }
+    if (firstNonemptyPartition == -1 && (!options.contains(VCFFileWriter.VCF_HEADER_KEY) ||
+      options
+        .get(VCFFileWriter.VCF_HEADER_KEY)
+        .contains(VCFFileWriter.INFER_HEADER))) {
+      throw new SparkException("Cannot infer header for empty VCF.")
     }
-
     rdd.mapPartitionsWithIndex {
       case (idx, it) =>
         val conf = serializableConf.value

--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -61,7 +61,8 @@ object BigVCFDatasource extends HlsUsageLogging {
         throw new SparkException("Cannot infer header for empty VCF.")
       }
       if (nParts == 0) {
-        throw new SparkException("Cannot write vcf because the DataFrame has zero partitions. " +
+        throw new SparkException(
+          "Cannot write vcf because the DataFrame has zero partitions. " +
           "Repartition to a positive number of partitions if you want to just write the header")
       }
     }

--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -49,6 +49,8 @@ object BigVCFDatasource extends HlsUsageLogging {
     val nParts = rdd.getNumPartitions
 
     if (nParts == 0) {
+
+
       throw new SparkException("The DataFrame is empty and has zero partitions. Cannot write vcf.")
     }
 

--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -71,8 +71,13 @@ object BigVCFDatasource extends HlsUsageLogging {
         DatabricksBGZFOutputStream.setWriteEmptyBlockOnClose(outputStream, idx == nParts - 1)
 
         // Write the header if this is the first nonempty partition
-        val writer =
-          new VCFFileWriter(options, dSchema, conf, outputStream, idx == firstNonemptyPartition)
+        val writer = new VCFFileWriter(
+          options,
+          dSchema,
+          conf,
+          outputStream,
+          (firstNonemptyPartition == -1 || idx == firstNonemptyPartition)
+        )
 
         it.foreach { row =>
           writer.write(row)

--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -71,12 +71,10 @@ object BigVCFDatasource extends HlsUsageLogging {
         DatabricksBGZFOutputStream.setWriteEmptyBlockOnClose(outputStream, idx == nParts - 1)
 
         // Write the header if this is the first nonempty partition
+        val partitionWithHeader = if (firstNonemptyPartition == -1) 0 else firstNonemptyPartition
 
-        val writer = if (firstNonemptyPartition == -1) {
-          new VCFFileWriter(options, dSchema, conf, outputStream, true)
-        } else {
-          new VCFFileWriter(options, dSchema, conf, outputStream, idx == firstNonemptyPartition)
-        }
+        val writer =
+          new VCFFileWriter(options, dSchema, conf, outputStream, idx == partitionWithHeader)
 
         it.foreach { row =>
           writer.write(row)

--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -18,7 +18,6 @@ package io.projectglow.vcf
 
 import java.io.ByteArrayOutputStream
 
-import htsjdk.variant.variantcontext.writer.{Options, VariantContextWriter, VariantContextWriterBuilder}
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.compress.CompressionCodecFactory
 import org.apache.spark.rdd.RDD
@@ -26,6 +25,7 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.sources.DataSourceRegister
 import org.seqdoop.hadoop_bam.util.DatabricksBGZFOutputStream
+
 import io.projectglow.common.logging.{HlsMetricDefinitions, HlsTagDefinitions, HlsTagValues, HlsUsageLogging}
 import io.projectglow.sql.BigFileDatasource
 import io.projectglow.sql.util.{ComDatabricksDataSource, SerializableConfiguration}
@@ -49,8 +49,6 @@ object BigVCFDatasource extends HlsUsageLogging {
     val nParts = rdd.getNumPartitions
 
     if (nParts == 0) {
-
-
       throw new SparkException("The DataFrame is empty and has zero partitions. Cannot write vcf.")
     }
 
@@ -65,7 +63,6 @@ object BigVCFDatasource extends HlsUsageLogging {
         .contains(VCFFileWriter.INFER_HEADER))) {
       throw new SparkException("Cannot infer header for empty VCF.")
     }
-
     rdd.mapPartitionsWithIndex {
       case (idx, it) =>
         val conf = serializableConf.value

--- a/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
@@ -366,15 +366,18 @@ abstract class VCFFileWriterSuite(val sourceName: String)
       .sparkContext
       .emptyRDD[VCFRow]
       .toDS
+      .repartition(1)
       .write
       .option("vcfHeader", NA12878)
       .format(sourceName)
       .save(tempFile)
+
     val rewrittenDs = spark
       .read
       .format(readSourceName)
       .option("vcfRowSchema", true)
       .load(tempFile)
+
     assert(rewrittenDs.collect.isEmpty)
   }
 }

--- a/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
@@ -36,7 +36,7 @@ import io.projectglow.common.{VCFRow, WithUtils}
 import io.projectglow.sql.GlowBaseTest
 
 abstract class VCFFileWriterSuite(val sourceName: String)
-    extends GlowBaseTest
+  extends GlowBaseTest
     with VCFConverterBaseTest {
 
   lazy val NA12878 = s"$testDataHome/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf"
@@ -56,11 +56,11 @@ abstract class VCFFileWriterSuite(val sourceName: String)
   }
 
   private def writeAndRereadWithDBParser(
-      vcf: String,
-      readSampleIds: Boolean = true,
-      rereadSampleIds: Boolean = true,
-      schemaOption: (String, String),
-      partitions: Option[Int] = None): (DataFrame, DataFrame) = {
+                                          vcf: String,
+                                          readSampleIds: Boolean = true,
+                                          rereadSampleIds: Boolean = true,
+                                          schemaOption: (String, String),
+                                          partitions: Option[Int] = None): (DataFrame, DataFrame) = {
 
     val tempFile = createTempVcf.toString
 
@@ -377,7 +377,13 @@ abstract class VCFFileWriterSuite(val sourceName: String)
       .format(readSourceName)
       .option("vcfRowSchema", true)
       .load(tempFile)
+
     assert(rewrittenDs.collect.isEmpty)
+
+    val truthHeader = VCFMetadataLoader.readVcfHeader(sparkContext.hadoopConfiguration, NA12878)
+    val writtenHeader = VCFMetadataLoader.readVcfHeader(sparkContext.hadoopConfiguration, tempFile)
+
+    assert(truthHeader.getMetaDataInInputOrder.equals(writtenHeader.getMetaDataInInputOrder))
   }
 }
 
@@ -422,7 +428,7 @@ class SingleFileVCFWriterSuite extends VCFFileWriterSuite("bigvcf") {
       // Empty gzip block only occurs once
       assert(
         bytes.indexOfSlice(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK) ==
-        bytes.lastIndexOfSlice(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK)
+          bytes.lastIndexOfSlice(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK)
       )
 
       // Empty gzip block is at end of file
@@ -473,9 +479,9 @@ class VCFWriterUtilsSuite extends GlowBaseTest {
   lazy val schema = spark.read.format("vcf").load(vcf).schema
 
   private def getHeaderNoSamples(
-      options: Map[String, String],
-      defaultOpt: Option[String],
-      schema: StructType): VCFHeader = {
+                                  options: Map[String, String],
+                                  defaultOpt: Option[String],
+                                  schema: StructType): VCFHeader = {
     val (headerLines, _) = VCFFileWriter.parseHeaderLinesAndSamples(
       options,
       defaultOpt,
@@ -490,10 +496,10 @@ class VCFWriterUtilsSuite extends GlowBaseTest {
 
   private def getAllLines(header: VCFHeader): Set[VCFHeaderLine] = {
     header.getContigLines.asScala.toSet ++
-    header.getFilterLines.asScala.toSet ++
-    header.getFormatHeaderLines.asScala.toSet ++
-    header.getInfoHeaderLines.asScala.toSet ++
-    header.getOtherHeaderLines.asScala.toSet
+      header.getFilterLines.asScala.toSet ++
+      header.getFormatHeaderLines.asScala.toSet ++
+      header.getInfoHeaderLines.asScala.toSet ++
+      header.getOtherHeaderLines.asScala.toSet
   }
 
   test("fall back") {
@@ -514,7 +520,7 @@ class VCFWriterUtilsSuite extends GlowBaseTest {
     val header = getHeaderNoSamples(Map("vcfHeader" -> vcf), None, schema)
     assert(
       getAllLines(header) ==
-      getAllLines(VCFMetadataLoader.readVcfHeader(sparkContext.hadoopConfiguration, vcf)))
+        getAllLines(VCFMetadataLoader.readVcfHeader(sparkContext.hadoopConfiguration, vcf)))
   }
 
   test("use literal header") {
@@ -525,7 +531,7 @@ class VCFWriterUtilsSuite extends GlowBaseTest {
         |##contig=<ID=monkey,length=42>
         |##source=DatabricksIsCool
         |""".stripMargin.trim + // write CHROM line by itself to preserve tabs
-      "\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA12878\n"
+        "\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA12878\n"
 
     val header = getHeaderNoSamples(Map("vcfHeader" -> contents), None, schema)
     val parsed = VCFFileWriter.parseHeaderFromString(contents)

--- a/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
@@ -494,6 +494,7 @@ class SingleFileVCFWriterSuite extends VCFFileWriterSuite("bigvcf") {
     val writtenHeader = VCFMetadataLoader.readVcfHeader(sparkContext.hadoopConfiguration, tempFile)
 
     assert(truthHeader.getMetaDataInInputOrder.equals(writtenHeader.getMetaDataInInputOrder))
+    assert(truthHeader.getGenotypeSamples == writtenHeader.getGenotypeSamples)
   }
 
   test("Bigvcf 0 partitions exception check") {

--- a/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
@@ -36,7 +36,7 @@ import io.projectglow.common.{VCFRow, WithUtils}
 import io.projectglow.sql.GlowBaseTest
 
 abstract class VCFFileWriterSuite(val sourceName: String)
-  extends GlowBaseTest
+    extends GlowBaseTest
     with VCFConverterBaseTest {
 
   lazy val NA12878 = s"$testDataHome/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf"
@@ -56,11 +56,11 @@ abstract class VCFFileWriterSuite(val sourceName: String)
   }
 
   private def writeAndRereadWithDBParser(
-                                          vcf: String,
-                                          readSampleIds: Boolean = true,
-                                          rereadSampleIds: Boolean = true,
-                                          schemaOption: (String, String),
-                                          partitions: Option[Int] = None): (DataFrame, DataFrame) = {
+      vcf: String,
+      readSampleIds: Boolean = true,
+      rereadSampleIds: Boolean = true,
+      schemaOption: (String, String),
+      partitions: Option[Int] = None): (DataFrame, DataFrame) = {
 
     val tempFile = createTempVcf.toString
 
@@ -428,7 +428,7 @@ class SingleFileVCFWriterSuite extends VCFFileWriterSuite("bigvcf") {
       // Empty gzip block only occurs once
       assert(
         bytes.indexOfSlice(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK) ==
-          bytes.lastIndexOfSlice(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK)
+        bytes.lastIndexOfSlice(BlockCompressedStreamConstants.EMPTY_GZIP_BLOCK)
       )
 
       // Empty gzip block is at end of file
@@ -479,9 +479,9 @@ class VCFWriterUtilsSuite extends GlowBaseTest {
   lazy val schema = spark.read.format("vcf").load(vcf).schema
 
   private def getHeaderNoSamples(
-                                  options: Map[String, String],
-                                  defaultOpt: Option[String],
-                                  schema: StructType): VCFHeader = {
+      options: Map[String, String],
+      defaultOpt: Option[String],
+      schema: StructType): VCFHeader = {
     val (headerLines, _) = VCFFileWriter.parseHeaderLinesAndSamples(
       options,
       defaultOpt,
@@ -496,10 +496,10 @@ class VCFWriterUtilsSuite extends GlowBaseTest {
 
   private def getAllLines(header: VCFHeader): Set[VCFHeaderLine] = {
     header.getContigLines.asScala.toSet ++
-      header.getFilterLines.asScala.toSet ++
-      header.getFormatHeaderLines.asScala.toSet ++
-      header.getInfoHeaderLines.asScala.toSet ++
-      header.getOtherHeaderLines.asScala.toSet
+    header.getFilterLines.asScala.toSet ++
+    header.getFormatHeaderLines.asScala.toSet ++
+    header.getInfoHeaderLines.asScala.toSet ++
+    header.getOtherHeaderLines.asScala.toSet
   }
 
   test("fall back") {
@@ -520,7 +520,7 @@ class VCFWriterUtilsSuite extends GlowBaseTest {
     val header = getHeaderNoSamples(Map("vcfHeader" -> vcf), None, schema)
     assert(
       getAllLines(header) ==
-        getAllLines(VCFMetadataLoader.readVcfHeader(sparkContext.hadoopConfiguration, vcf)))
+      getAllLines(VCFMetadataLoader.readVcfHeader(sparkContext.hadoopConfiguration, vcf)))
   }
 
   test("use literal header") {
@@ -531,7 +531,7 @@ class VCFWriterUtilsSuite extends GlowBaseTest {
         |##contig=<ID=monkey,length=42>
         |##source=DatabricksIsCool
         |""".stripMargin.trim + // write CHROM line by itself to preserve tabs
-        "\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA12878\n"
+      "\n#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tNA12878\n"
 
     val header = getHeaderNoSamples(Map("vcfHeader" -> contents), None, schema)
     val parsed = VCFFileWriter.parseHeaderFromString(contents)

--- a/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
@@ -495,6 +495,25 @@ class SingleFileVCFWriterSuite extends VCFFileWriterSuite("bigvcf") {
 
     assert(truthHeader.getMetaDataInInputOrder.equals(writtenHeader.getMetaDataInInputOrder))
   }
+
+  test("Bigvcf 0 partitions exception check") {
+    val sess = spark
+    import sess.implicits._
+
+    val tempFile = createTempVcf.toString
+
+    assertThrows[SparkException](
+      spark
+        .sparkContext
+        .emptyRDD[VCFRow]
+        .toDS
+        .write
+        .option("vcfHeader", NA12878)
+        .format(sourceName)
+        .save(tempFile)
+    )
+  }
+
 }
 
 class VCFWriterUtilsSuite extends GlowBaseTest {

--- a/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
@@ -366,10 +366,12 @@ abstract class VCFFileWriterSuite(val sourceName: String)
       .sparkContext
       .emptyRDD[VCFRow]
       .toDS
+      .repartition(1)
       .write
       .option("vcfHeader", NA12878)
       .format(sourceName)
       .save(tempFile)
+
     val rewrittenDs = spark
       .read
       .format(readSourceName)

--- a/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
@@ -366,24 +366,16 @@ abstract class VCFFileWriterSuite(val sourceName: String)
       .sparkContext
       .emptyRDD[VCFRow]
       .toDS
-      .repartition(1)
       .write
       .option("vcfHeader", NA12878)
       .format(sourceName)
       .save(tempFile)
-
     val rewrittenDs = spark
       .read
       .format(readSourceName)
       .option("vcfRowSchema", true)
       .load(tempFile)
-
     assert(rewrittenDs.collect.isEmpty)
-
-    val truthHeader = VCFMetadataLoader.readVcfHeader(sparkContext.hadoopConfiguration, NA12878)
-    val writtenHeader = VCFMetadataLoader.readVcfHeader(sparkContext.hadoopConfiguration, tempFile)
-
-    assert(truthHeader.getMetaDataInInputOrder.equals(writtenHeader.getMetaDataInInputOrder))
   }
 }
 
@@ -471,6 +463,34 @@ class SingleFileVCFWriterSuite extends VCFFileWriterSuite("bigvcf") {
 
     val rereadDs = spark.read.format("vcf").load(tempFile)
     assert(rereadDs.sort("start").collect sameElements ds.sort("start").collect)
+  }
+
+  test("Bigvcf header check for empty file with determined header") {
+    val sess = spark
+    import sess.implicits._
+
+    val tempFile = createTempVcf.toString
+
+    spark
+      .sparkContext
+      .emptyRDD[VCFRow]
+      .toDS
+      .repartition(1)
+      .write
+      .option("vcfHeader", NA12878)
+      .format(sourceName)
+      .save(tempFile)
+
+    val rewrittenDs = spark
+      .read
+      .format(readSourceName)
+      .option("vcfRowSchema", true)
+      .load(tempFile)
+
+    val truthHeader = VCFMetadataLoader.readVcfHeader(sparkContext.hadoopConfiguration, NA12878)
+    val writtenHeader = VCFMetadataLoader.readVcfHeader(sparkContext.hadoopConfiguration, tempFile)
+
+    assert(truthHeader.getMetaDataInInputOrder.equals(writtenHeader.getMetaDataInInputOrder))
   }
 }
 


### PR DESCRIPTION
Signed-off-by: kianfar77 <kiavash.kianfar@databricks.com>

## What changes are proposed in this pull request?
#67 results in an empty vcf file if an empty dataframe is passed along with a determined header to bigvcf writer. This PR adds a condition to fix this, i.e., make sure the header is written although the DataFrame is empty. Also if number of partitions is 0 (which can happen) an appropriate message is emitted. 

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
