### PR TITLE
Persist RDDs and Datasets on disk by default

### DIFF
--- a/core/src/main/scala/io/projectglow/common/WithUtils.scala
+++ b/core/src/main/scala/io/projectglow/common/WithUtils.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.locks.Lock
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Dataset
+import org.apache.spark.storage.StorageLevel
 
 import scala.util.control.NonFatal
 
@@ -71,7 +72,7 @@ object WithUtils {
   }
 
   def withCachedRDD[T, U](rdd: RDD[T])(f: RDD[T] => U): U = {
-    rdd.cache()
+    rdd.persist(StorageLevel.MEMORY_AND_DISK)
     try {
       f(rdd)
     } finally {
@@ -80,7 +81,7 @@ object WithUtils {
   }
 
   def withCachedDataset[T, U](ds: Dataset[T])(f: Dataset[T] => U): U = {
-    ds.cache()
+    ds.persist(StorageLevel.MEMORY_AND_DISK)
     try {
       f(ds)
     } finally {

--- a/core/src/main/scala/io/projectglow/common/WithUtils.scala
+++ b/core/src/main/scala/io/projectglow/common/WithUtils.scala
@@ -72,7 +72,7 @@ object WithUtils {
   }
 
   def withCachedRDD[T, U](rdd: RDD[T])(f: RDD[T] => U): U = {
-    rdd.persist(StorageLevel.MEMORY_AND_DISK)
+    rdd.persist(StorageLevel.DISK_ONLY)
     try {
       f(rdd)
     } finally {
@@ -81,7 +81,7 @@ object WithUtils {
   }
 
   def withCachedDataset[T, U](ds: Dataset[T])(f: Dataset[T] => U): U = {
-    ds.persist(StorageLevel.MEMORY_AND_DISK)
+    ds.persist(StorageLevel.DISK_ONLY)
     try {
       f(ds)
     } finally {

--- a/core/src/main/scala/io/projectglow/common/WithUtils.scala
+++ b/core/src/main/scala/io/projectglow/common/WithUtils.scala
@@ -72,6 +72,7 @@ object WithUtils {
   }
 
   def withCachedRDD[T, U](rdd: RDD[T])(f: RDD[T] => U): U = {
+    // Caching in MEMORY_ONLY (or even MEMORY_AND_DISK) can result in OOMs
     rdd.persist(StorageLevel.DISK_ONLY)
     try {
       f(rdd)
@@ -81,6 +82,7 @@ object WithUtils {
   }
 
   def withCachedDataset[T, U](ds: Dataset[T])(f: Dataset[T] => U): U = {
+    // Caching in MEMORY_ONLY (or even MEMORY_AND_DISK) can result in OOMs
     ds.persist(StorageLevel.DISK_ONLY)
     try {
       f(ds)

--- a/core/src/main/scala/io/projectglow/common/WithUtils.scala
+++ b/core/src/main/scala/io/projectglow/common/WithUtils.scala
@@ -72,7 +72,7 @@ object WithUtils {
   }
 
   def withCachedRDD[T, U](rdd: RDD[T])(f: RDD[T] => U): U = {
-    rdd.persist(StorageLevel.MEMORY_AND_DISK_SER)
+    rdd.persist(StorageLevel.DISK_ONLY)
     try {
       f(rdd)
     } finally {
@@ -81,7 +81,7 @@ object WithUtils {
   }
 
   def withCachedDataset[T, U](ds: Dataset[T])(f: Dataset[T] => U): U = {
-    ds.persist(StorageLevel.MEMORY_AND_DISK_SER)
+    ds.persist(StorageLevel.DISK_ONLY)
     try {
       f(ds)
     } finally {

--- a/core/src/main/scala/io/projectglow/common/WithUtils.scala
+++ b/core/src/main/scala/io/projectglow/common/WithUtils.scala
@@ -72,7 +72,7 @@ object WithUtils {
   }
 
   def withCachedRDD[T, U](rdd: RDD[T])(f: RDD[T] => U): U = {
-    rdd.persist(StorageLevel.DISK_ONLY)
+    rdd.persist(StorageLevel.MEMORY_AND_DISK_SER)
     try {
       f(rdd)
     } finally {
@@ -81,7 +81,7 @@ object WithUtils {
   }
 
   def withCachedDataset[T, U](ds: Dataset[T])(f: Dataset[T] => U): U = {
-    ds.persist(StorageLevel.DISK_ONLY)
+    ds.persist(StorageLevel.MEMORY_AND_DISK_SER)
     try {
       f(ds)
     } finally {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Writing with the big VCF datasource results in OOMs and/or an exorbitant amount of GC when we cache in memory if the DataFrame to be written is large. Even if we cache as `MEMORY_AND_DISK`, we can still run out of heap space as executors drop off before they can fall back to caching on disk. Caching on disk is probably the safest option.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

Tested with a variety of storage levels; `DISK_ONLY` is the only one that works even when there is a very limited amount of memory (a single c5.xlarge worker).
