### PR TITLE
Add links to Glow sites

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,9 +1,9 @@
 Glow
 ====
 
-Glow is an open-source toolkit for working with genomic data at biobank-scale and beyond. The
-toolkit is natively built on Apache Spark, the leading unified engine for big data processing and
-machine learning, enabling the scale of the cloud for genomics workflows.
+`Glow <https://projectglow.io/>`_ is an `open-source <https://github.com/projectglow/glow>`_ toolkit for working with
+genomic data at biobank-scale and beyond. The toolkit is natively built on Apache Spark, the leading unified engine for
+big data processing and machine learning, enabling the scale of the cloud for genomics workflows.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds documentation links to Glow homepage and Github page.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

`make livehtml` looks good!