### PR TITLE
Inject Spark session rules during SQL extension registration

### DIFF
--- a/core/src/main/scala/io/projectglow/Glow.scala
+++ b/core/src/main/scala/io/projectglow/Glow.scala
@@ -19,10 +19,10 @@ package io.projectglow
 import java.util.ServiceLoader
 
 import scala.collection.JavaConverters._
-
-import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.{DataFrame, SQLUtils, SparkSession}
 
 import io.projectglow.common.Named
+import io.projectglow.sql.{GlowSQLExtensions, SqlExtensionProvider}
 import io.projectglow.transformers.util.{SnakeCaseMap, StringUtils}
 
 /**
@@ -33,6 +33,13 @@ import io.projectglow.transformers.util.{SnakeCaseMap, StringUtils}
  * generic methods with stringly-typed arguments to reduce language-specific maintenance burden.
  */
 class GlowBase {
+
+  def register(spark: SparkSession): Unit = {
+    new GlowSQLExtensions().apply(SQLUtils.getSessionExtensions(spark))
+    SqlExtensionProvider.registerFunctions(
+      spark.sessionState.conf,
+      spark.sessionState.functionRegistry)
+  }
 
   /**
    * Apply a named transformation to a DataFrame of genomic data. All parameters apart from the

--- a/core/src/main/scala/io/projectglow/Glow.scala
+++ b/core/src/main/scala/io/projectglow/Glow.scala
@@ -19,6 +19,7 @@ package io.projectglow
 import java.util.ServiceLoader
 
 import scala.collection.JavaConverters._
+
 import org.apache.spark.sql.{DataFrame, SQLUtils, SparkSession}
 
 import io.projectglow.common.Named

--- a/core/src/main/scala/io/projectglow/sql/SqlExtensionProvider.scala
+++ b/core/src/main/scala/io/projectglow/sql/SqlExtensionProvider.scala
@@ -41,10 +41,6 @@ class GlowSQLExtensions extends (SparkSessionExtensions => Unit) {
 
 object SqlExtensionProvider {
 
-  final def register(session: SparkSession): Unit = {
-    registerFunctions(session.sessionState.conf, session.sessionState.functionRegistry)
-  }
-
   def registerFunctions(conf: SQLConf, functionRegistry: FunctionRegistry): Unit = {
     functionRegistry.registerFunction(
       FunctionIdentifier("add_struct_fields"),

--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -237,12 +237,12 @@ object VCFFileFormat {
       } else {
         new PositionalBufferedStream(is)
       }
-
-      val vcfCodec = new VCFCodec()
-      val reader = new AsciiLineReaderIterator(AsciiLineReader.from(wrappedStream))
-      val header = vcfCodec
-        .readActualHeader(reader)
-      (header.asInstanceOf[VCFHeader], vcfCodec)
+      WithUtils.withCloseable(wrappedStream) { ws =>
+        val vcfCodec = new VCFCodec()
+        val reader = new AsciiLineReaderIterator(AsciiLineReader.from(ws))
+        val header = vcfCodec.readActualHeader(reader)
+        (header.asInstanceOf[VCFHeader], vcfCodec)
+      }
     }
   }
 

--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -237,12 +237,10 @@ object VCFFileFormat {
       } else {
         new PositionalBufferedStream(is)
       }
-      WithUtils.withCloseable(wrappedStream) { ws =>
-        val vcfCodec = new VCFCodec()
-        val reader = new AsciiLineReaderIterator(AsciiLineReader.from(ws))
-        val header = vcfCodec.readActualHeader(reader)
-        (header.asInstanceOf[VCFHeader], vcfCodec)
-      }
+      val vcfCodec = new VCFCodec()
+      val reader = new AsciiLineReaderIterator(AsciiLineReader.from(wrappedStream))
+      val header = vcfCodec.readActualHeader(reader)
+      (header.asInstanceOf[VCFHeader], vcfCodec)
     }
   }
 

--- a/core/src/main/scala/org/apache/spark/sql/SQLUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SQLUtils.scala
@@ -75,4 +75,8 @@ object SQLUtils {
   def anyDataType: ADT = AnyDataType
 
   type ADT = AbstractDataType
+
+  def getSessionExtensions(session: SparkSession): SparkSessionExtensions = {
+    session.extensions
+  }
 }

--- a/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
+++ b/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
@@ -24,6 +24,7 @@ import org.scalatest.concurrent.{AbstractPatienceConfiguration, Eventually}
 import org.scalatest.time.{Milliseconds, Seconds, Span}
 import org.scalatest.{Args, FunSuite, Status, Tag}
 
+import io.projectglow.Glow
 import io.projectglow.common.{GlowLogging, TestUtils}
 import io.projectglow.sql.util.BGZFCodec
 
@@ -46,15 +47,13 @@ abstract class GlowBaseTest
         "spark.hadoop.io.compression.codecs",
         classOf[BGZFCodec].getCanonicalName
       )
-      .set("spark.sql.extensions", classOf[GlowSQLExtensions].getCanonicalName)
-
   }
 
   override def initializeSession(): Unit = ()
 
   override protected implicit def spark: SparkSession = {
     val sess = SparkSession.builder().config(sparkConf).master("local[2]").getOrCreate()
-    SqlExtensionProvider.register(sess)
+    Glow.register(sess)
     SparkSession.setActiveSession(sess)
     Log.setGlobalLogLevel(Log.LogLevel.ERROR)
     sess

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,6 +79,7 @@ extensions = [
     'sphinx.ext.githubpages',
     'notebook',
     'sphinx_substitution_extensions',
+    'sphinx_tabs.tabs',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -58,8 +58,7 @@ Glow requires Apache Spark 2.4.3 (or a later version of Spark 2.4.x that is buil
 
           ./bin/spark-shell --packages io.projectglow:glow_2.11:|mvn-version|
 
-        And now your notebook is glowing! To access the Glow functions, you need to register them with the
-        Spark session.
+        To access the Glow functions, you need to register them with the Spark session.
 
         .. code-block:: scala
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -4,42 +4,68 @@ Getting Started
 Running Locally
 ---------------
 
-Glow requires Apache Spark 2.4.3 (or a later version of Spark 2.4.x that is built on Scala 2.11). If you don't have a
-local Apache Spark installation, you can install it from PyPI:
+Glow requires Apache Spark 2.4.3 (or a later version of Spark 2.4.x that is built on Scala 2.11).
 
-.. code-block:: sh
+.. tabs::
 
-  pip install pyspark==2.4.3
+    .. tab:: Python
 
-or `download a specific distribution <https://spark.apache.org/downloads.html>`_.
+        If you don't have a local Apache Spark installation, you can install it from PyPI:
 
-Install the Python frontend from pip:
+        .. code-block:: sh
 
-.. code-block:: sh
+          pip install pyspark==2.4.3
 
-  pip install glow.py
+        or `download a specific distribution <https://spark.apache.org/downloads.html>`_.
 
-and then start the `Spark shell <http://spark.apache.org/docs/latest/rdd-programming-guide.html#using-the-shell>`_
-with the Glow maven package:
+        Install the Python frontend from pip:
 
-.. substitution-code-block:: sh
+        .. code-block:: sh
 
-  ./bin/pyspark --packages io.projectglow:glow_2.11:|mvn-version|
+          pip install glow.py
 
-To start a Jupyter notebook instead of a shell:
+        and then start the `Spark shell <http://spark.apache.org/docs/latest/rdd-programming-guide.html#using-the-shell>`_
+        with the Glow maven package:
 
-.. substitution-code-block:: sh
+        .. substitution-code-block:: sh
 
-  PYSPARK_DRIVER_PYTHON=jupyter PYSPARK_DRIVER_PYTHON_OPTS=notebook ./bin/pyspark --packages io.projectglow:glow_2.11:|mvn-version|
+          ./bin/pyspark --packages io.projectglow:glow_2.11:|mvn-version|
 
-And now your notebook is glowing! To access the Glow functions, you need to register them with the
-Spark session.
+        To start a Jupyter notebook instead of a shell:
 
-.. code-block:: python
+        .. substitution-code-block:: sh
 
-  import glow
-  glow.register(spark)
-  df = spark.read.format('vcf').load('my_first.vcf')
+          PYSPARK_DRIVER_PYTHON=jupyter PYSPARK_DRIVER_PYTHON_OPTS=notebook ./bin/pyspark --packages io.projectglow:glow_2.11:|mvn-version|
+
+        And now your notebook is glowing! To access the Glow functions, you need to register them with the
+        Spark session.
+
+        .. code-block:: python
+
+          import glow
+          glow.register(spark)
+          df = spark.read.format('vcf').load('example.vcf')
+
+    .. tab:: Scala
+
+        If you don't have a local Apache Spark installation,
+        `download a specific distribution <https://spark.apache.org/downloads.html>`_.
+
+        Start the `Spark shell <http://spark.apache.org/docs/latest/rdd-programming-guide.html#using-the-shell>`_
+        with the Glow maven package:
+
+        .. substitution-code-block:: sh
+
+          ./bin/spark-shell --packages io.projectglow:glow_2.11:|mvn-version|
+
+        And now your notebook is glowing! To access the Glow functions, you need to register them with the
+        Spark session.
+
+        .. code-block:: scala
+
+          import io.projectglow.Glow
+          Glow.register(spark)
+          val df = spark.read.format("vcf").load("example.vcf")
 
 Running in the cloud
 --------------------

--- a/docs/source/tertiary/pipe-transformer.rst
+++ b/docs/source/tertiary/pipe-transformer.rst
@@ -5,19 +5,40 @@ Parallelizing Command-Line Tools With the Pipe Transformer
 To use single-node tools on massive data sets, Glow includes a
 utility called the Pipe Transformer to process Spark DataFrames with command-line programs.
 
-Python usage
-============
+Usage
+=====
 
 Consider a minimal case with a DataFrame containing a single column of strings. You can use the Pipe
 Transformer to reverse each of the strings in the input DataFrame using the ``rev`` Linux command:
 
-.. code-block:: py
+.. tabs::
 
-  import glow
+    .. tab:: Python
 
-  # Create a text-only DataFrame
-  df = spark.createDataFrame([['foo'], ['bar'], ['baz']], ['value'])
-  display(glow.transform('pipe', df, cmd='["rev"]', input_formatter='text', output_formatter='text'))
+        Provide options through the ``arg_map`` argument or as keyword args.
+
+        .. code-block:: py
+
+          import glow
+
+          # Create a text-only DataFrame
+          df = spark.createDataFrame([['foo'], ['bar'], ['baz']], ['value'])
+          display(glow.transform('pipe', df, cmd='["rev"]', input_formatter='text', output_formatter='text'))
+
+    .. tab:: Scala
+
+        Provide options as a ``Map[String, String]``.
+
+        .. code-block:: scala
+
+            import io.projectglow.Glow
+
+            Glow.transform("pipe", df, Map(
+                "cmd" -> "[\"grep\", \"-v\", \"#INFO\"]",
+                "inputFormatter" -> "vcf",
+                "outputFormatter" -> "vcf",
+                "inVcfHeader" -> "infer")
+            )
 
 The options in this example demonstrate how to control the basic behavior of the transformer:
 
@@ -54,32 +75,15 @@ When you use the VCF input formatter, you must specify a method to determine the
 simplest option is ``infer``, which instructs the Pipe Transformer to derive a VCF header from the
 DataFrame schema.
 
-Scala usage
-===========
 
-You can also invoke the Pipe Transformer from Scala. You specify options as a ``Map[String,
-String]``.
-
-.. code-block:: scala
-
-  import io.projectglow.Glow
-
-  Glow.transform("pipe", df, Map(
-    "cmd" -> "[\"grep\", \"-v\", \"#INFO\"]",
-    "inputFormatter" -> "vcf",
-    "outputFormatter" -> "vcf",
-    "inVcfHeader" -> "infer")
-  )
 
 .. _transformer-options:
 
 Options
 =======
 
-Option keys and values are always strings. From Python, you provide options through the ``arg_map``
-argument or as keyword args. From Scala, you provide options as a ``Map[String, String]``.
-You can specify option names in snake or camel case; for example ``inputFormatter``, 
-``input_formatter``, and ``InputFormatter`` are all equivalent.
+Option keys and values are always strings. You can specify option names in snake or camel case; for example
+``inputFormatter``, ``input_formatter``, and ``InputFormatter`` are all equivalent.
 
 .. list-table::
   :header-rows: 1
@@ -135,7 +139,18 @@ instead of waiting for them to fall out of the cache, use the pipe cleanup trans
 cleanup until the pipe transformer results have been materialized, such as by being written to a
 `Delta Lake table <https://delta.io>`_.
 
-To perform pipe cleanup in Python, run ``glow.transform('pipe_cleanup', df)``.
-In Scala, run ``Glow.transform("pipe_cleanup", df)``.
+.. tabs::
+
+    .. tab:: Python
+
+        .. code-block:: py
+
+          glow.transform('pipe_cleanup', df)
+
+    .. tab:: Scala
+
+        .. code-block:: scala
+
+            Glow.transform("pipe_cleanup", df)
 
 .. notebook:: .. tertiary/pipe-transformer.html

--- a/docs/source/tertiary/variant-normalization.rst
+++ b/docs/source/tertiary/variant-normalization.rst
@@ -12,23 +12,25 @@ Glow provides the ``normalize_variants`` transformer to be applied on a variant 
   * The variant normalization algorithm used by the ``normlize_variants`` transformer follows the same logic as the one used in well-known normalization tools such as `bcftools norm <http://www.htslib.org/doc/bcftools.html#norm>`_ or `vt normalize <https://genome.sph.umich.edu/wiki/Vt#Normalization>`_ tools. This normalization logic is different from the one use by GATK's `LeftAlignAndTrimVariants <https://software.broadinstitute.org/gatk/documentation/tooldocs/3.8-0/org_broadinstitute_gatk_tools_walkers_variantutils_LeftAlignAndTrimVariants.php>`_, which sometimes yields incorrect normalization (see `Variant Normalization <https://genome.sph.umich.edu/wiki/Variant_Normalization>`_ for more details).
   * The splitting logic is the same as the one used in GATK's `LeftAlignAndTrimVariants <https://software.broadinstitute.org/gatk/documentation/tooldocs/3.8-0/org_broadinstitute_gatk_tools_walkers_variantutils_LeftAlignAndTrimVariants.php>`_ tool using ``--splitMultiallelics`` option. In splitting a multiallelic variant, this transformer recalculates the GT blocks for the resulting biallelic variants if possible, and drops all VCF INFO fields, except for AC, AN, and AF, which are recalculated based on the newly calculated GT blocks, if any, and otherwise dropped.
 
-Python usage
-============
-Assuming ``df_original`` is a variable of type DataFrame which contains the genomic variant records, and ``ref_genome_path`` is a variable of type String containing the path to the reference genome file, a minimal example of using this transformer for normalization in Python is:
+Usage
+=====
 
-.. code-block:: py
+Assuming ``df_original`` is a variable of type DataFrame which contains the genomic variant records, and ``ref_genome_path`` is a variable of type String containing the path to the reference genome file, a minimal example of using this transformer for normalization is:
 
-  import glow
-  df_normalized = glow.transform("normalize_variants", df_original, reference_genome_path=ref_genome_path)
+.. tabs::
 
-Scala usage
-===========
-The same can be done in Scala as follows:
+    .. tab:: Python
 
-.. code-block:: scala
+        .. code-block:: py
+            import glow
+            df_normalized = glow.transform("normalize_variants", df_original, reference_genome_path=ref_genome_path)
 
-    import io.projectglow.Glow
-    df_normalized = Glow.transform("normalize_variants", df_original, Map("reference_genome_path" -> ref_genome_path))
+    .. tab:: Scala
+
+        .. code-block:: scala
+
+            import io.projectglow.Glow
+            df_normalized = Glow.transform("normalize_variants", df_original, Map("reference_genome_path" -> ref_genome_path))
 
 Options
 =======

--- a/python/environment.yml
+++ b/python/environment.yml
@@ -10,3 +10,4 @@ dependencies:
     - twine==2.0.0 # Pypi publishing
     - sphinx_rtd_theme
     - Sphinx-Substitution-Extensions==2019.6.15.0 # Substitutions in code blocks
+    - sphinx-tabs # Code tabs (Python/Scala)

--- a/python/glow/glow.py
+++ b/python/glow/glow.py
@@ -37,9 +37,10 @@ def register(session: SparkSession):
     """
     register(session)
 
-    Register SQL extensions for a Spark session.
+    Register SQL extensions and inject the relevant rules for a Spark session.
 
     :param session: Spark session
     """
     assert check_argument_types()
     session._jvm.io.projectglow.sql.SqlExtensionProvider.register(session._jsparkSession)
+    session._jvm.io.projectglow.sql.GlowSQLExtensions().apply(session._jsparkSession.extensions())

--- a/python/glow/glow.py
+++ b/python/glow/glow.py
@@ -37,9 +37,9 @@ def register(session: SparkSession):
     """
     register(session)
 
-    Register SQL extensions and inject the relevant rules for a Spark session.
+    Register SQL extensions for a Spark session.
 
     :param session: Spark session
     """
     assert check_argument_types()
-    session._jvm.io.projectglow.sql.SqlExtensionProvider.register(session._jsparkSession)
+    session._jvm.io.projectglow.Glow.register(session._jsparkSession)

--- a/python/glow/glow.py
+++ b/python/glow/glow.py
@@ -43,4 +43,3 @@ def register(session: SparkSession):
     """
     assert check_argument_types()
     session._jvm.io.projectglow.sql.SqlExtensionProvider.register(session._jsparkSession)
-    session._jvm.io.projectglow.sql.GlowSQLExtensions().apply(session._jsparkSession.extensions())


### PR DESCRIPTION
## What changes are proposed in this pull request?

When Glow is attached as a library (vs. being baked into a Spark runtime), we need to inject the rules in addition to registering the extensions. As the rules are needed for the extensions to function properly, it makes sense for simplicity's sake to perform the injection during the `glow.register(spark)` step. This PR also exposes the same `Glow.register(spark)` API in Scala, and simplifies documentation for Scala users by creating distinct Python/Scala tabs for language-specific docs.

Resolves https://github.com/projectglow/glow/issues/86.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

Replicated the attached issue in a Jupyter notebook. After running the following step in a cell:
```
spark.sparkContext._jvm.io.projectglow.sql.GlowSQLExtensions().apply(spark._jsparkSession.extensions())
```
The command succeeded.