### PR TITLE
Add permute array

### DIFF
--- a/core/src/main/scala/io/projectglow/sql/SqlExtensionProvider.scala
+++ b/core/src/main/scala/io/projectglow/sql/SqlExtensionProvider.scala
@@ -30,7 +30,8 @@ import io.projectglow.sql.optimizer.{HLSReplaceExpressionsRule, ResolveAggregate
 // TODO(hhd): Spark 3.0 allows extensions to register functions. After Spark 3.0 is released,
 // we should move all extensions into this class.
 class GlowSQLExtensions extends (SparkSessionExtensions => Unit) {
-  val resolutionRules: Seq[Rule[LogicalPlan]] = Seq(ResolveAggregateFunctionsRule, HLSReplaceExpressionsRule)
+  val resolutionRules: Seq[Rule[LogicalPlan]] =
+    Seq(ResolveAggregateFunctionsRule, HLSReplaceExpressionsRule)
   val optimizations: Seq[Rule[LogicalPlan]] = Seq()
   def apply(extensions: SparkSessionExtensions): Unit = {
 

--- a/core/src/main/scala/io/projectglow/sql/SqlExtensionProvider.scala
+++ b/core/src/main/scala/io/projectglow/sql/SqlExtensionProvider.scala
@@ -30,8 +30,8 @@ import io.projectglow.sql.optimizer.{HLSReplaceExpressionsRule, ResolveAggregate
 // TODO(hhd): Spark 3.0 allows extensions to register functions. After Spark 3.0 is released,
 // we should move all extensions into this class.
 class GlowSQLExtensions extends (SparkSessionExtensions => Unit) {
-  val resolutionRules: Seq[Rule[LogicalPlan]] = Seq(ResolveAggregateFunctionsRule)
-  val optimizations: Seq[Rule[LogicalPlan]] = Seq(HLSReplaceExpressionsRule)
+  val resolutionRules: Seq[Rule[LogicalPlan]] = Seq(ResolveAggregateFunctionsRule, HLSReplaceExpressionsRule)
+  val optimizations: Seq[Rule[LogicalPlan]] = Seq()
   def apply(extensions: SparkSessionExtensions): Unit = {
 
     resolutionRules.foreach(r => extensions.injectResolutionRule(_ => r))
@@ -159,6 +159,11 @@ object SqlExtensionProvider {
     functionRegistry.registerFunction(
       FunctionIdentifier("vector_to_array"),
       exprs => VectorToArray(exprs.head)
+    )
+
+    functionRegistry.registerFunction(
+      FunctionIdentifier("permute_array"),
+      exprs => PermuteArray(exprs.head, exprs.last)
     )
   }
 }

--- a/core/src/main/scala/io/projectglow/sql/expressions/glueExpressions.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/glueExpressions.scala
@@ -67,6 +67,21 @@ case class AddStructFields(struct: Expression, newFields: Seq[Expression])
 }
 
 /**
+ * Expression that rearranges and/or subsets an array by an array of indices.
+ *
+ * The logic of this expression is implemented in [[HLSReplaceExpressionsRule]].
+ */
+case class PermuteArray(dataArray: Expression, indexArray: Expression)
+    extends Expression
+    with Unevaluable {
+
+  override def nullable: Boolean = true
+  override def children: Seq[Expression] = Seq(dataArray, indexArray)
+  override def dataType: DataType = dataArray.dataType
+
+}
+
+/**
  * Explodes a matrix by row. Each row of the input matrix will be output as an array of doubles.
  *
  * If the input expression is null or has 0 rows, the output will be empty.

--- a/core/src/test/scala/io/projectglow/tertiary/PermuteArrayExprSuite.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/PermuteArrayExprSuite.scala
@@ -1,9 +1,25 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectglow.tertiary
 
 import io.projectglow.sql.GlowBaseTest
 import org.apache.spark.sql.functions.{lit, when}
 
-class PermuteArrayExprSuite extends GlowBaseTest{
+class PermuteArrayExprSuite extends GlowBaseTest {
 
   private lazy val sess = spark
 
@@ -11,31 +27,41 @@ class PermuteArrayExprSuite extends GlowBaseTest{
     val dataArray = Array(5, 6, 7, 8)
     val indexArray = Array(1, 2)
     val aRow = spark.range(1).select(lit(dataArray) as "dataArray", lit(indexArray) as "indexArray")
-    val permutedData = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+    val permutedData = aRow
+      .selectExpr("permute_array(dataArray,indexArray) as permutedData")
       .take(1)
-      .map(r => r.getAs[Seq[Int]]("permutedData")).head
-    assert(permutedData == indexArray.map(i => dataArray(i-1)).toSeq)
+      .map(r => r.getAs[Seq[Int]]("permutedData"))
+      .head
+    assert(permutedData == indexArray.map(i => dataArray(i - 1)).toSeq)
   }
 
   test(testName = "null indices") {
     import sess.implicits._
     val dataArray = Array(5, 6, 7, 8)
-    val aRow = spark.range(1).select(lit(dataArray) as "dataArray", lit(null).cast("array<int>") as "indexArray")
-    val nullCheck = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+    val aRow = spark
+      .range(1)
+      .select(lit(dataArray) as "dataArray", lit(null).cast("array<int>") as "indexArray")
+    val nullCheck = aRow
+      .selectExpr("permute_array(dataArray,indexArray) as permutedData")
       .withColumn("nullCheck", when($"permutedData".isNull, lit(true)).otherwise(lit(false)))
       .take(1)
-      .map(r => r.getAs[Boolean]("nullCheck")).head
+      .map(r => r.getAs[Boolean]("nullCheck"))
+      .head
     assert(nullCheck)
   }
 
   test(testName = "null data") {
     import sess.implicits._
     val indexArray = Array(3, 2)
-    val aRow = spark.range(1).select(lit(null).cast("array<double>") as "dataArray", lit(indexArray) as "indexArray")
-    val nullCheck = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+    val aRow = spark
+      .range(1)
+      .select(lit(null).cast("array<double>") as "dataArray", lit(indexArray) as "indexArray")
+    val nullCheck = aRow
+      .selectExpr("permute_array(dataArray,indexArray) as permutedData")
       .withColumn("nullCheck", when($"permutedData".isNull, lit(true)).otherwise(lit(false)))
       .take(1)
-      .map(r => r.getAs[Boolean]("nullCheck")).head
+      .map(r => r.getAs[Boolean]("nullCheck"))
+      .head
     assert(nullCheck)
   }
 
@@ -44,10 +70,12 @@ class PermuteArrayExprSuite extends GlowBaseTest{
     val dataArray = Array(5, 6, 7, 8)
     val indexArray = Array(2, 3, 4, 5)
     val aRow = spark.range(1).select(lit(dataArray) as "dataArray", lit(indexArray) as "indexArray")
-    val nullCheck = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+    val nullCheck = aRow
+      .selectExpr("permute_array(dataArray,indexArray) as permutedData")
       .withColumn("nullCheck", when($"permutedData".isNull, lit(true)).otherwise(lit(false)))
       .take(1)
-      .map(r => r.getAs[Boolean]("nullCheck")).head
+      .map(r => r.getAs[Boolean]("nullCheck"))
+      .head
     assert(nullCheck)
   }
 
@@ -56,10 +84,12 @@ class PermuteArrayExprSuite extends GlowBaseTest{
     val dataArray = Array(5, 6, 7, 8)
     val indexArray = Array(0, 1, 2, 3)
     val aRow = spark.range(1).select(lit(dataArray) as "dataArray", lit(indexArray) as "indexArray")
-    val nullCheck = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+    val nullCheck = aRow
+      .selectExpr("permute_array(dataArray,indexArray) as permutedData")
       .withColumn("nullCheck", when($"permutedData".isNull, lit(true)).otherwise(lit(false)))
       .take(1)
-      .map(r => r.getAs[Boolean]("nullCheck")).head
+      .map(r => r.getAs[Boolean]("nullCheck"))
+      .head
     assert(nullCheck)
   }
 
@@ -67,9 +97,11 @@ class PermuteArrayExprSuite extends GlowBaseTest{
     val dataArray = Array(5, 6, 7, 8)
     val indexArray = Array.empty[Int]
     val aRow = spark.range(1).select(lit(dataArray) as "dataArray", lit(indexArray) as "indexArray")
-    val permutedData = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+    val permutedData = aRow
+      .selectExpr("permute_array(dataArray,indexArray) as permutedData")
       .take(1)
-      .map(r => r.getAs[Seq[Int]]("permutedData")).head
+      .map(r => r.getAs[Seq[Int]]("permutedData"))
+      .head
     assert(permutedData.isEmpty)
   }
 
@@ -78,10 +110,12 @@ class PermuteArrayExprSuite extends GlowBaseTest{
     val dataArray = Array.empty[String]
     val indexArray = Array(0, 1, 2, 3, 4)
     val aRow = spark.range(1).select(lit(dataArray) as "dataArray", lit(indexArray) as "indexArray")
-    val nullCheck = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+    val nullCheck = aRow
+      .selectExpr("permute_array(dataArray,indexArray) as permutedData")
       .withColumn("nullCheck", when($"permutedData".isNull, lit(true)).otherwise(lit(false)))
       .take(1)
-      .map(r => r.getAs[Boolean]("nullCheck")).head
+      .map(r => r.getAs[Boolean]("nullCheck"))
+      .head
     assert(nullCheck)
   }
 

--- a/core/src/test/scala/io/projectglow/tertiary/PermuteArrayExprSuite.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/PermuteArrayExprSuite.scala
@@ -1,0 +1,88 @@
+package io.projectglow.tertiary
+
+import io.projectglow.sql.GlowBaseTest
+import org.apache.spark.sql.functions.{lit, when}
+
+class PermuteArrayExprSuite extends GlowBaseTest{
+
+  private lazy val sess = spark
+
+  test("basic test") {
+    val dataArray = Array(5, 6, 7, 8)
+    val indexArray = Array(1, 2)
+    val aRow = spark.range(1).select(lit(dataArray) as "dataArray", lit(indexArray) as "indexArray")
+    val permutedData = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+      .take(1)
+      .map(r => r.getAs[Seq[Int]]("permutedData")).head
+    assert(permutedData == indexArray.map(i => dataArray(i-1)).toSeq)
+  }
+
+  test(testName = "null indices") {
+    import sess.implicits._
+    val dataArray = Array(5, 6, 7, 8)
+    val aRow = spark.range(1).select(lit(dataArray) as "dataArray", lit(null).cast("array<int>") as "indexArray")
+    val nullCheck = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+      .withColumn("nullCheck", when($"permutedData".isNull, lit(true)).otherwise(lit(false)))
+      .take(1)
+      .map(r => r.getAs[Boolean]("nullCheck")).head
+    assert(nullCheck)
+  }
+
+  test(testName = "null data") {
+    import sess.implicits._
+    val indexArray = Array(3, 2)
+    val aRow = spark.range(1).select(lit(null).cast("array<double>") as "dataArray", lit(indexArray) as "indexArray")
+    val nullCheck = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+      .withColumn("nullCheck", when($"permutedData".isNull, lit(true)).otherwise(lit(false)))
+      .take(1)
+      .map(r => r.getAs[Boolean]("nullCheck")).head
+    assert(nullCheck)
+  }
+
+  test(testName = "index too large") {
+    import sess.implicits._
+    val dataArray = Array(5, 6, 7, 8)
+    val indexArray = Array(2, 3, 4, 5)
+    val aRow = spark.range(1).select(lit(dataArray) as "dataArray", lit(indexArray) as "indexArray")
+    val nullCheck = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+      .withColumn("nullCheck", when($"permutedData".isNull, lit(true)).otherwise(lit(false)))
+      .take(1)
+      .map(r => r.getAs[Boolean]("nullCheck")).head
+    assert(nullCheck)
+  }
+
+  test(testName = "index too small") {
+    import sess.implicits._
+    val dataArray = Array(5, 6, 7, 8)
+    val indexArray = Array(0, 1, 2, 3)
+    val aRow = spark.range(1).select(lit(dataArray) as "dataArray", lit(indexArray) as "indexArray")
+    val nullCheck = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+      .withColumn("nullCheck", when($"permutedData".isNull, lit(true)).otherwise(lit(false)))
+      .take(1)
+      .map(r => r.getAs[Boolean]("nullCheck")).head
+    assert(nullCheck)
+  }
+
+  test(testName = "empty indices") {
+    val dataArray = Array(5, 6, 7, 8)
+    val indexArray = Array.empty[Int]
+    val aRow = spark.range(1).select(lit(dataArray) as "dataArray", lit(indexArray) as "indexArray")
+    val permutedData = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+      .take(1)
+      .map(r => r.getAs[Seq[Int]]("permutedData")).head
+    assert(permutedData.isEmpty)
+  }
+
+  test(testName = "empty data") {
+    import sess.implicits._
+    val dataArray = Array.empty[String]
+    val indexArray = Array(0, 1, 2, 3, 4)
+    val aRow = spark.range(1).select(lit(dataArray) as "dataArray", lit(indexArray) as "indexArray")
+    val nullCheck = aRow.selectExpr("permute_array(dataArray,indexArray) as permutedData")
+      .withColumn("nullCheck", when($"permutedData".isNull, lit(true)).otherwise(lit(false)))
+      .take(1)
+      .map(r => r.getAs[Boolean]("nullCheck")).head
+    assert(nullCheck)
+  }
+
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
Added new sql expression permute_array, which is used to subset and/or reorder an array with a given array of indices

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

