### PR TITLE
Linkcheck databricks.com

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -226,10 +226,3 @@ intersphinx_mapping = {'https://docs.python.org/': None}
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
-
-# -- Linkcheck options -------------------------------------------------------
-
-linkcheck_ignore = [
-    # Currently experiencing server issues
-    r'https://databricks.com*',
-]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Reverts https://github.com/projectglow/glow/pull/70 now that the Databricks site appears to be stable.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

`curl -I https://databricks.com` works reliably.
