### PR TITLE
Add option to specify bgzf

### DIFF
--- a/core/src/main/scala/io/projectglow/common/datasourceOptions.scala
+++ b/core/src/main/scala/io/projectglow/common/datasourceOptions.scala
@@ -27,6 +27,7 @@ object VCFOptions {
   val VCF_ROW_SCHEMA = "vcfRowSchema"
   val USE_TABIX_INDEX = "useTabixIndex"
   val USE_FILTER_PARSER = "useFilterParser"
+  val IS_BGZF = "isBgzf"
 
   // Writer-only options
   val COMPRESSION = "compression"

--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -71,7 +71,8 @@ class VCFFileFormat extends TextBasedFileFormat with DataSourceRegister with Hls
     codecFactory.getCodec(path) match {
       case null => true
       case _: BGZFEnhancedGzipCodec =>
-        VCFFileFormat.isValidBGZ(path, sparkSession.sparkContext.hadoopConfiguration)
+        options.get(VCFOptions.IS_BGZF).exists(_.toBoolean) ||
+          VCFFileFormat.isValidBGZ(path, sparkSession.sparkContext.hadoopConfiguration)
       case c => c.isInstanceOf[SplittableCompressionCodec]
     }
   }

--- a/core/src/test/scala/io/projectglow/vcf/VCFDatasourceSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFDatasourceSuite.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Dataset}
 import org.apache.spark.{SparkConf, SparkException}
 
-import io.projectglow.common.{GenotypeFields, VCFRow}
+import io.projectglow.common.{GenotypeFields, VCFOptions, VCFRow}
 import io.projectglow.sql.GlowBaseTest
 
 class VCFDatasourceSuite extends GlowBaseTest {
@@ -539,6 +539,13 @@ class VCFDatasourceSuite extends GlowBaseTest {
 
     assert(vcfFormat.isSplitable(spark, Map.empty, bgzPath))
     assert(csvFormat.isSplitable(spark, Map.empty, bgzPath))
+  }
+
+  test("isBgzf option") {
+    val vcfFormat = new VCFFileFormat()
+    val path = new Path(s"$testDataHome/vcf/1row_not_bgz.vcf.gz")
+    assert(!vcfFormat.isSplitable(spark, Map.empty, path))
+    assert(vcfFormat.isSplitable(spark, Map(VCFOptions.IS_BGZF -> "true"), path))
   }
 
   test("Tolerate lower-case nan's") {


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
Inferring whether input files are bgzf can be quite slow when there are many files because we need to open a file stream. There's not a straightforward way to parallelize this in the file format interface, so we can add an option to force bgzf.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
