### PR TITLE
Move gzip check to file reading

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -55,8 +55,6 @@ class VCFFileFormat extends TextBasedFileFormat with DataSourceRegister with Hls
   /**
    * This is very similar to [[TextBasedFileFormat.isSplitable()]], but with additional check
    * for files that may or may not be block gzipped.
-   *
-   * The check for BGZIP compression is adapted from [[org.seqdoop.hadoop_bam.VCFInputFormat]].
    */
   override def isSplitable(
       sparkSession: SparkSession,
@@ -68,6 +66,8 @@ class VCFFileFormat extends TextBasedFileFormat with DataSourceRegister with Hls
       )
     }
 
+    // Note: we check if a file is gzipped vs block gzipped during reading, so this will be true
+    // for .gz files even if they aren't actually splittable
     codecFactory.getCodec(path).isInstanceOf[SplittableCompressionCodec]
   }
 

--- a/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
+++ b/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
@@ -86,7 +86,7 @@ abstract class GlowBaseTest
     res
   }
 
-  protected def withConf[T](configs: Map[String, String])(f: => T): T = {
+  protected def withSparkConf[T](configs: Map[String, String])(f: => T): T = {
     val initialConfigValues = configs.keys.map(k => (k, spark.conf.getOption(k)))
     try {
       configs.foreach { case (k, v) => spark.conf.set(k, v) }

--- a/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
+++ b/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
@@ -85,6 +85,19 @@ abstract class GlowBaseTest
     }
     res
   }
+
+  protected def withConf[T](configs: Map[String, String])(f: => T): T = {
+    val initialConfigValues = configs.keys.map(k => (k, spark.conf.getOption(k)))
+    try {
+      configs.foreach { case (k, v) => spark.conf.set(k, v) }
+      f
+    } finally {
+      initialConfigValues.foreach {
+        case (k, Some(v)) => spark.conf.set(k, v)
+        case (k, None) => spark.conf.unset(k)
+      }
+    }
+  }
 }
 
 /**

--- a/core/src/test/scala/io/projectglow/vcf/TabixHelperSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/TabixHelperSuite.scala
@@ -16,9 +16,13 @@
 
 package io.projectglow.vcf
 
+import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.PartitionedFile
 import org.apache.spark.sql.sources._
 import org.broadinstitute.hellbender.utils.SimpleInterval
+import org.seqdoop.hadoop_bam.util.BGZFEnhancedGzipCodec
 
 import io.projectglow.common.{GlowLogging, VCFRow}
 import io.projectglow.sql.GlowBaseTest
@@ -32,12 +36,7 @@ class TabixHelperSuite extends GlowBaseTest with GlowLogging {
   lazy val testBigVcf = s"$tabixTestVcf/1000G.phase3.broad.withGenotypes.chr20.10100000.vcf.gz"
   lazy val multiAllelicVcf = s"$tabixTestVcf/combined.chr20_18210071_18210093.g.vcf.gz"
   lazy val testNoTbiVcf = s"$tabixTestVcf/NA12878_21_10002403NoTbi.vcf.gz"
-
-  override def sparkConf: SparkConf = {
-    super
-      .sparkConf
-      .set("spark.hadoop.io.compression.codecs", "org.seqdoop.hadoop_bam.util.BGZFCodec")
-  }
+  lazy val oneRowGzipVcf = s"$testDataHome/vcf/1row_not_bgz.vcf.gz"
 
   def printFilterContig(filterContig: FilterContig): Unit = {
     filterContig.getContigName.foreach(i => logger.debug(s"$i"))
@@ -693,6 +692,19 @@ class TabixHelperSuite extends GlowBaseTest with GlowLogging {
       .load(testNoTbiVcf)
       .filter("contigName= '21' and start = 10002435")
     df.rdd.count()
+  }
+
+  test("gzip files") {
+    val path = new Path(oneRowGzipVcf)
+    val conf = sparkContext.hadoopConfiguration
+    val fs = path.getFileSystem(conf)
+    val fileLength = fs.getFileStatus(path).getLen
+    val partitionedFile = PartitionedFile(InternalRow.empty, oneRowGzipVcf, 0, 2)
+    val interval = Some(new SimpleInterval("0", 1, 2))
+    assert(TabixIndexHelper.getFileRangeToRead(fs, partitionedFile, conf, false, false, interval).contains((0l, fileLength)))
+
+    val partitionedFileWithoutStart = partitionedFile.copy(start = 1)
+    assert(TabixIndexHelper.getFileRangeToRead(fs, partitionedFileWithoutStart, conf, false, false, interval).isEmpty)
   }
 
   /**

--- a/core/src/test/scala/io/projectglow/vcf/VCFDatasourceSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFDatasourceSuite.scala
@@ -477,7 +477,7 @@ class VCFDatasourceSuite extends GlowBaseTest {
     val path = s"$testDataHome/vcf/1row_not_bgz.vcf.gz"
     val key = "spark.sql.files.maxPartitionBytes"
     val conf = Map("spark.sql.files.maxPartitionBytes" -> "10")
-    withConf(conf) {
+    withSparkConf(conf) {
       assert(spark.read.format(sourceName).load(path).count() == 1)
     }
   }

--- a/core/src/test/scala/io/projectglow/vcf/VCFDatasourceSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFDatasourceSuite.scala
@@ -473,10 +473,13 @@ class VCFDatasourceSuite extends GlowBaseTest {
     assert(rowIter.isEmpty)
   }
 
-  test("gzip'd files are not considered to be splittable") {
-    val fileFormat = new VCFFileFormat()
+  test("gzip splits are only read if they contain the beginning of the file") {
     val path = s"$testDataHome/vcf/1row_not_bgz.vcf.gz"
-    assert(!fileFormat.isSplitable(spark, Map.empty, new Path(path)))
+    val key = "spark.sql.files.maxPartitionBytes"
+    val conf = Map("spark.sql.files.maxPartitionBytes" -> "10")
+    withConf(conf) {
+      assert(spark.read.format(sourceName).load(path).count() == 1)
+    }
   }
 
   test("misnumbered fields") {


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
Previously we checked whether a .vcf.gz file was block gzipped in `VCFFileFormat.isSplittable`. Although this location is logically the right place, Spark runs this code on each file serially. Since checking whether a file is gzipped or block gzipped requires reading the part of the file, this process can be very slow on large datasets.

Instead, we now handle the difference between gz and bgz while reading files. If we detect that a file is gzipped, we read the entire file if the current split starts at the beginning of the file and read nothing if it starts in the middle. Note that this is not the ideal behavior since we're creating a ton of tasks that do nothing. However, in the common case where .gz actually means block gzip, we can now skip the expensive serial check without requiring more user input.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
