### PR TITLE
Parse INFO attribute arrays from strings

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/VariantContextToInternalRowConverter.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VariantContextToInternalRowConverter.scala
@@ -302,11 +302,14 @@ class VariantContextToInternalRowConverter(
         case BooleanType => true: java.lang.Boolean
         case ArrayType(StringType, _) =>
           val strings = vc.getAttributeAsStringList(realName, "")
-          val strList = if (strings.size > 1) {
-            makeArray(strings.asScala.toArray, UTF8String.fromString)
-          } else {
-            getAttributeArray(vc, realName, UTF8String.fromString)
-          }
+          val strList =
+            if (strings.size == 1 && strings
+                .get(0)
+                .indexOf(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR) > -1) {
+              makeArray(strings.asScala.toArray, UTF8String.fromString)
+            } else {
+              getAttributeArray(vc, realName, UTF8String.fromString)
+            }
           new GenericArrayData(strList)
         case ArrayType(IntegerType, _) =>
           val intList = try {

--- a/core/src/main/scala/io/projectglow/vcf/VariantContextToInternalRowConverter.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VariantContextToInternalRowConverter.scala
@@ -263,6 +263,25 @@ class VariantContextToInternalRowConverter(
     row.update(idx, new ArrayBasedMapData(new GenericArrayData(keys), new GenericArrayData(values)))
   }
 
+  private def makeArray(strings: Array[String], parseFn: String => Any): Array[Any] = {
+    val arr = new Array[Any](strings.length)
+    var i = 0
+    while (i < arr.length) {
+      arr(i) = parseFn(strings(i))
+      i += 1
+    }
+    arr
+  }
+
+  // Fall back on parsing a comma-separated list
+  private def getAttributeArray(
+      vc: VariantContext,
+      key: String,
+      parseFn: String => Any): Array[Any] = {
+    val strArray = vc.getAttributeAsString(key, "").split(VCFConstants.INFO_FIELD_ARRAY_SEPARATOR)
+    makeArray(strArray, parseFn)
+  }
+
   private def updateInfoField(
       vc: VariantContext,
       field: StructField,
@@ -283,17 +302,28 @@ class VariantContextToInternalRowConverter(
         case BooleanType => true: java.lang.Boolean
         case ArrayType(StringType, _) =>
           val strings = vc.getAttributeAsStringList(realName, "")
-          val arr = new Array[Any](strings.size)
-          var i = 0
-          while (i < strings.size) {
-            arr(i) = UTF8String.fromString(strings.get(i))
-            i += 1
+          val strList = if (strings.size > 1) {
+            makeArray(strings.asScala.toArray, UTF8String.fromString)
+          } else {
+            getAttributeArray(vc, realName, UTF8String.fromString)
           }
-          new GenericArrayData(arr)
+          new GenericArrayData(strList)
         case ArrayType(IntegerType, _) =>
-          new GenericArrayData(vc.getAttributeAsIntList(realName, 0).asScala)
+          val intList = try {
+            vc.getAttributeAsIntList(realName, 0).asScala
+          } catch {
+            case _: NumberFormatException =>
+              getAttributeArray(vc, realName, _.toInt)
+          }
+          new GenericArrayData(intList)
         case ArrayType(DoubleType, _) =>
-          new GenericArrayData(vc.getAttributeAsDoubleList(realName, 0).asScala)
+          val doubleList = try {
+            vc.getAttributeAsDoubleList(realName, 0).asScala
+          } catch {
+            case _: NumberFormatException =>
+              getAttributeArray(vc, realName, _.toDouble)
+          }
+          new GenericArrayData(doubleList)
       }
       if (value != null) {
         row.update(idx, value)

--- a/core/src/main/scala/io/projectglow/vcf/VariantContextToInternalRowConverter.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VariantContextToInternalRowConverter.scala
@@ -22,6 +22,7 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.util.control.NonFatal
+
 import htsjdk.samtools.ValidationStringency
 import htsjdk.tribble.util.ParsingUtils
 import htsjdk.variant.variantcontext.{Allele, VariantContext, Genotype => HTSJDKGenotype}
@@ -31,6 +32,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, GenericArrayData}
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
+
 import io.projectglow.common.{GenotypeFields, GlowLogging, HasStringency, VariantSchemas}
 import io.projectglow.sql.util.RowConverter
 

--- a/core/src/test/scala/io/projectglow/vcf/VariantContextToInternalRowConverterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VariantContextToInternalRowConverterSuite.scala
@@ -16,8 +16,6 @@
 
 package io.projectglow.vcf
 
-import java.util.Arrays
-
 import scala.collection.JavaConverters._
 
 import htsjdk.samtools.ValidationStringency

--- a/core/src/test/scala/io/projectglow/vcf/VariantContextToInternalRowConverterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VariantContextToInternalRowConverterSuite.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectglow.vcf
+
+import java.util.Arrays
+
+import scala.collection.JavaConverters._
+
+import htsjdk.samtools.ValidationStringency
+import htsjdk.variant.variantcontext.{Allele, VariantContextBuilder}
+import htsjdk.variant.vcf.{VCFHeader, VCFHeaderLine, VCFHeaderLineType, VCFInfoHeaderLine}
+import io.projectglow.sql.GlowBaseTest
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.unsafe.types.UTF8String
+
+class VariantContextToInternalRowConverterSuite extends GlowBaseTest {
+
+  gridTest("Array fields converted to strings")(Seq(true, false)) { arrToStr =>
+    val intArrayHeaderLine =
+      new VCFInfoHeaderLine("IntArray", 2, VCFHeaderLineType.Integer, "Integer array")
+    val strArrayHeaderLine =
+      new VCFInfoHeaderLine("StringArray", 3, VCFHeaderLineType.String, "String array")
+    val floatArrayHeaderLine =
+      new VCFInfoHeaderLine("FloatArray", 4, VCFHeaderLineType.Float, "Float array")
+    val headerLines = Seq(intArrayHeaderLine, strArrayHeaderLine, floatArrayHeaderLine)
+
+    val vcfHeader = new VCFHeader(headerLines.map(_.asInstanceOf[VCFHeaderLine]).toSet.asJava)
+    val schema = VCFSchemaInferrer.inferSchema(true, true, vcfHeader)
+    val converter =
+      new VariantContextToInternalRowConverter(vcfHeader, schema, ValidationStringency.STRICT)
+
+    val vcb = new VariantContextBuilder("Unknown", "chr1", 1, 1, Seq(Allele.REF_A).asJava)
+    val intArray = Array(1, 2)
+    val strArray = Array("foo", "bar", "baz").map(UTF8String.fromString)
+    val floatArray = Array(0.1, 1.2, 2.3, 3.4)
+
+    if (arrToStr) {
+      vcb.attribute(intArrayHeaderLine.getID, intArray.mkString(","))
+      vcb.attribute(strArrayHeaderLine.getID, strArray.mkString(","))
+      vcb.attribute(floatArrayHeaderLine.getID, floatArray.mkString(","))
+    } else {
+      vcb.attribute(intArrayHeaderLine.getID, intArray)
+      vcb.attribute(strArrayHeaderLine.getID, strArray)
+      vcb.attribute(floatArrayHeaderLine.getID, floatArray)
+    }
+    val vc = vcb.make
+
+    val internalRow = converter.convertRow(vc, false)
+    assert(
+      internalRow
+        .getArray(schema.fieldIndex("INFO_" + intArrayHeaderLine.getID))
+        .toIntArray() sameElements intArray)
+    assert(
+      internalRow
+        .getArray(schema.fieldIndex("INFO_" + strArrayHeaderLine.getID))
+        .toObjectArray(StringType) sameElements strArray)
+    assert(
+      internalRow
+        .getArray(schema.fieldIndex("INFO_" + floatArrayHeaderLine.getID))
+        .toDoubleArray() sameElements floatArray)
+  }
+}

--- a/core/src/test/scala/io/projectglow/vcf/VariantContextToInternalRowConverterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VariantContextToInternalRowConverterSuite.scala
@@ -23,9 +23,10 @@ import scala.collection.JavaConverters._
 import htsjdk.samtools.ValidationStringency
 import htsjdk.variant.variantcontext.{Allele, VariantContextBuilder}
 import htsjdk.variant.vcf.{VCFHeader, VCFHeaderLine, VCFHeaderLineType, VCFInfoHeaderLine}
-import io.projectglow.sql.GlowBaseTest
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.unsafe.types.UTF8String
+
+import io.projectglow.sql.GlowBaseTest
 
 class VariantContextToInternalRowConverterSuite extends GlowBaseTest {
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Sometimes, VariantContext array-based attributes are stored as a comma-separated string. This currently breaks the `VariantContextToInternalRowConverter` if the validation stringency is strict, and incorrectly sets the field to `null` otherwise.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
