### PR TITLE
Take strings instead of FileStatuses in VCFHeaderUtils

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -468,7 +468,7 @@ private[vcf] object SchemaDelegate {
       spark: SparkSession,
       files: Seq[FileStatus]): (Seq[VCFInfoHeaderLine], Seq[VCFFormatHeaderLine]) = {
     VCFHeaderUtils
-      .readHeaderLines(spark, files)
+      .readHeaderLines(spark, files.map(_.getPath.toString))
       .partition {
         case _: VCFInfoHeaderLine => true
         case _: VCFFormatHeaderLine => false

--- a/core/src/main/scala/io/projectglow/vcf/VCFHeaderUtils.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFHeaderUtils.scala
@@ -25,8 +25,6 @@ import com.google.common.annotations.VisibleForTesting
 import htsjdk.variant.vcf.{VCFCodec, VCFCompoundHeaderLine, VCFHeader, VCFHeaderLine}
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.FileStatus
-import org.apache.spark
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.StructType
@@ -88,13 +86,12 @@ object VCFHeaderUtils extends GlowLogging {
     }
   }
 
-  def createHeaderRDD(spark: SparkSession, files: Seq[FileStatus]): RDD[VCFHeader] = {
+  def createHeaderRDD(spark: SparkSession, files: Seq[String]): RDD[VCFHeader] = {
     val serializableConf = new SerializableConfiguration(spark.sessionState.newHadoopConf())
 
-    val filePaths = files.map(_.getPath.toString)
     spark
       .sparkContext
-      .parallelize(filePaths)
+      .parallelize(files)
       .map { path =>
         val (header, _) = VCFFileFormat.createVCFCodec(path, serializableConf.value)
         header
@@ -108,11 +105,10 @@ object VCFHeaderUtils extends GlowLogging {
    */
   def getUniqueHeaderLines(headers: RDD[VCFHeader]): Seq[VCFCompoundHeaderLine] = {
     headers.flatMap { header =>
-        val infoHeaderLines = header.getInfoHeaderLines.asScala
-        val formatHeaderLines = header.getFormatHeaderLines.asScala
-        infoHeaderLines ++ formatHeaderLines
-      }
-      .keyBy(line => (line.getClass.getName, line.getID))
+      val infoHeaderLines = header.getInfoHeaderLines.asScala
+      val formatHeaderLines = header.getFormatHeaderLines.asScala
+      infoHeaderLines ++ formatHeaderLines
+    }.keyBy(line => (line.getClass.getName, line.getID))
       .reduceByKey {
         case (line1, line2) =>
           if (line1.equalsExcludingDescription(line2)) {
@@ -131,7 +127,7 @@ object VCFHeaderUtils extends GlowLogging {
    * A convenience function to parse the headers from a set of VCF files and return the unique
    * header lines.
    */
-  def readHeaderLines(spark: SparkSession, files: Seq[FileStatus]): Seq[VCFCompoundHeaderLine] = {
+  def readHeaderLines(spark: SparkSession, files: Seq[String]): Seq[VCFCompoundHeaderLine] = {
     getUniqueHeaderLines(createHeaderRDD(spark, files))
   }
 }

--- a/core/src/test/scala/io/projectglow/vcf/TabixHelperSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/TabixHelperSuite.scala
@@ -701,10 +701,16 @@ class TabixHelperSuite extends GlowBaseTest with GlowLogging {
     val fileLength = fs.getFileStatus(path).getLen
     val partitionedFile = PartitionedFile(InternalRow.empty, oneRowGzipVcf, 0, 2)
     val interval = Some(new SimpleInterval("0", 1, 2))
-    assert(TabixIndexHelper.getFileRangeToRead(fs, partitionedFile, conf, false, false, interval).contains((0l, fileLength)))
+    assert(
+      TabixIndexHelper
+        .getFileRangeToRead(fs, partitionedFile, conf, false, false, interval)
+        .contains((0L, fileLength)))
 
     val partitionedFileWithoutStart = partitionedFile.copy(start = 1)
-    assert(TabixIndexHelper.getFileRangeToRead(fs, partitionedFileWithoutStart, conf, false, false, interval).isEmpty)
+    assert(
+      TabixIndexHelper
+        .getFileRangeToRead(fs, partitionedFileWithoutStart, conf, false, false, interval)
+        .isEmpty)
   }
 
   /**

--- a/core/src/test/scala/io/projectglow/vcf/VCFHeaderUtilsSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFHeaderUtilsSuite.scala
@@ -63,7 +63,7 @@ class VCFHeaderUtilsSuite extends GlowBaseTest {
     header.getInfoHeaderLines.asScala.toSet ++
     header.getOtherHeaderLines.asScala.toSet
 
-  private def writeVCFHeaders(contents: Seq[String], nSamples: Int = 1): Seq[FileStatus] = {
+  private def writeVCFHeaders(contents: Seq[String], nSamples: Int = 1): Seq[String] = {
     val dir = Files.createTempDirectory(this.getClass.getSimpleName)
     val paths = contents.indices.map(idx => dir.resolve(idx.toString))
     contents.zip(paths).foreach {
@@ -77,9 +77,7 @@ class VCFHeaderUtilsSuite extends GlowBaseTest {
          """.stripMargin
         FileUtils.writeStringToFile(path.toFile, StringContext.treatEscapes(fullContents.trim()))
     }
-    new Path(dir.toString)
-      .getFileSystem(spark.sparkContext.hadoopConfiguration)
-      .listStatus(new Path(dir.toString))
+    paths.map(_.toString)
   }
 
   test("fall back") {


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
This makes it easier to call into from places where you might not have FileStatuses.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
