### PR TITLE
Unflake VCFPiperSuite

### DIFF
--- a/core/src/test/scala/io/projectglow/vcf/VCFPiperSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFPiperSuite.scala
@@ -255,7 +255,7 @@ class VCFPiperSuite extends GlowBaseTest {
     assertThrows[IllegalArgumentException](Glow.transform("pipe", inputDf, options))
   }
 
-  test(s"output validation stringency") {
+  test("output validation stringency") {
     val row = Seq("1", "1", "id", "C", "T,GT", "1", ".", "AC=monkey").mkString("\t")
 
     val file = Files.createTempFile("test-vcf", ".vcf")

--- a/core/src/test/scala/io/projectglow/vcf/VCFPiperSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFPiperSuite.scala
@@ -255,33 +255,31 @@ class VCFPiperSuite extends GlowBaseTest {
     assertThrows[IllegalArgumentException](Glow.transform("pipe", inputDf, options))
   }
 
-  Range(1, 10000).foreach { i =>
-    test(s"output validation stringency ${i}") {
-      val row = Seq("1", "1", "id", "C", "T,GT", "1", ".", "AC=monkey").mkString("\t")
+  test(s"output validation stringency") {
+    val row = Seq("1", "1", "id", "C", "T,GT", "1", ".", "AC=monkey").mkString("\t")
 
-      val file = Files.createTempFile("test-vcf", ".vcf")
-      val header =
-        s"""##fileformat=VCFv4.2
-           |##INFO=<ID=AC,Number=1,Type=Integer,Description="">
-           |#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
+    val file = Files.createTempFile("test-vcf", ".vcf")
+    val header =
+      s"""##fileformat=VCFv4.2
+         |##INFO=<ID=AC,Number=1,Type=Integer,Description="">
+         |#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO
         """.stripMargin
-      FileUtils.writeStringToFile(file.toFile, header + row)
+    FileUtils.writeStringToFile(file.toFile, header + row)
 
-      val inputDf = spark
-        .read
-        .format("vcf")
-        .load(TGP)
+    val inputDf = spark
+      .read
+      .format("vcf")
+      .load(TGP)
 
-      val options = Map(
-        "inputFormatter" -> "vcf",
-        "outputFormatter" -> "vcf",
-        "inVcfHeader" -> "infer",
-        "outValidationStringency" -> "STRICT",
-        "cmd" -> s"""["cat", "$file"]"""
-      )
-      val e = intercept[SparkException](Glow.transform("pipe", inputDf, options))
-      assert(e.getCause.isInstanceOf[IllegalArgumentException])
-    }
+    val options = Map(
+      "inputFormatter" -> "vcf",
+      "outputFormatter" -> "vcf",
+      "inVcfHeader" -> "infer",
+      "outValidationStringency" -> "STRICT",
+      "cmd" -> s"""["cat", "$file"]"""
+    )
+    val e = intercept[SparkException](Glow.transform("pipe", inputDf, options))
+    assert(e.getCause.isInstanceOf[IllegalArgumentException])
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
I believe that the test could previously fail because the output formatter would throw an exception while the input formatter still had a stream open. Now, we wait for all threads to be shut down before we do the leaked stream check.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
