### PR TITLE
Fixes bigVcfWrite logging 

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -77,6 +77,14 @@ object BigVCFDatasource extends HlsUsageLogging {
     }
     val validationStringency = VCFOptionParser.getValidationStringency(options)
 
+    // record bigVcfWrite event in the log
+    recordHlsUsage(
+      HlsMetricDefinitions.EVENT_HLS_USAGE,
+      Map(
+        HlsTagDefinitions.TAG_EVENT_TYPE -> HlsTagValues.EVENT_BIGVCF_WRITE
+      )
+    )
+
     rdd.mapPartitionsWithIndex {
       case (idx, it) =>
         val conf = serializableConf.value
@@ -107,14 +115,6 @@ object BigVCFDatasource extends HlsUsageLogging {
         }
 
         writer.close()
-
-        // record bigVcfWrite event in the log
-        recordHlsUsage(
-          HlsMetricDefinitions.EVENT_HLS_USAGE,
-          Map(
-            HlsTagDefinitions.TAG_EVENT_TYPE -> HlsTagValues.EVENT_BIGVCF_WRITE
-          )
-        )
 
         Iterator(baos.toByteArray)
     }


### PR DESCRIPTION
Signed-off-by: kianfar77 <kiavash.kianfar@databricks.com>

## What changes are proposed in this pull request?
Fixes logging of bigVcfWrite event to happen once per call instead of once per partition. 

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

(Details)
