### PR TITLE
Record one big VCF write event per file

### DIFF
--- a/core/src/main/scala/io/projectglow/bgen/BgenFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/bgen/BgenFileFormat.scala
@@ -35,11 +35,15 @@ import org.apache.spark.sql.types.StructType
 import org.skife.jdbi.v2.DBI
 import org.skife.jdbi.v2.util.LongMapper
 
-import io.projectglow.common.logging.{HlsMetricDefinitions, HlsTagDefinitions, HlsTagValues, HlsUsageLogging}
-import io.projectglow.common.{BgenOptions, GlowLogging, WithUtils}
+import io.projectglow.common.logging.{HlsEventRecorder, HlsTagValues}
+import io.projectglow.common.{BgenOptions, WithUtils}
 import io.projectglow.sql.util.{ComDatabricksDataSource, SerializableConfiguration}
 
-class BgenFileFormat extends FileFormat with DataSourceRegister with Serializable with GlowLogging {
+class BgenFileFormat
+    extends FileFormat
+    with DataSourceRegister
+    with Serializable
+    with HlsEventRecorder {
 
   override def shortName(): String = "bgen"
 
@@ -81,7 +85,7 @@ class BgenFileFormat extends FileFormat with DataSourceRegister with Serializabl
     val sampleIdsOpt = BgenFileFormat.getSampleIds(options, hadoopConf)
 
     // record bgenRead event in the log along with the option
-    BgenFileFormat.logBgenRead(options)
+    recordHlsEvent(HlsTagValues.EVENT_BGEN_READ, Map(BgenOptions.USE_INDEX_KEY -> useIndex))
 
     val serializableConf = new SerializableConfiguration(hadoopConf)
 
@@ -173,7 +177,7 @@ class BgenFileFormat extends FileFormat with DataSourceRegister with Serializabl
 
 class ComDatabricksBgenFileFormat extends BgenFileFormat with ComDatabricksDataSource
 
-object BgenFileFormat extends HlsUsageLogging {
+object BgenFileFormat {
   import io.projectglow.common.BgenOptions._
 
   val BGEN_SUFFIX = ".bgen"
@@ -236,19 +240,5 @@ object BgenFileFormat extends HlsUsageLogging {
 
       Some(sampleIds)
     }
-  }
-
-  def logBgenRead(options: Map[String, String]): Unit = {
-
-    val logOptions = Map(
-      USE_INDEX_KEY -> options.get(USE_INDEX_KEY).forall(_.toBoolean)
-    )
-    recordHlsUsage(
-      HlsMetricDefinitions.EVENT_HLS_USAGE,
-      Map(
-        HlsTagDefinitions.TAG_EVENT_TYPE -> HlsTagValues.EVENT_BGEN_READ
-      ),
-      blob = hlsJsonBuilder(logOptions)
-    )
   }
 }

--- a/core/src/main/scala/io/projectglow/bgen/BigBgenDatasource.scala
+++ b/core/src/main/scala/io/projectglow/bgen/BigBgenDatasource.scala
@@ -52,7 +52,7 @@ object BigBgenDatasource extends HlsEventRecorder {
     BigBgenOptions(bitsPerProb, maxPloidy, defaultPloidy, defaultPhasing)
   }
 
-  private def logWrite(parsedOptions: BigBgenOptions): Unit = {
+  private def logBgenWrite(parsedOptions: BigBgenOptions): Unit = {
     val logOptions = Map(
       BITS_PER_PROB_KEY -> parsedOptions.bitsPerProb,
       MAX_PLOIDY_KEY -> parsedOptions.maxPloidy,
@@ -67,7 +67,7 @@ object BigBgenDatasource extends HlsEventRecorder {
     val numVariants = data.count
     val parsedOptions = parseOptions(options)
 
-    logWrite(parsedOptions)
+    logBgenWrite(parsedOptions)
 
     data.queryExecution.toRdd.mapPartitionsWithIndex {
       case (idx, it) =>

--- a/core/src/main/scala/io/projectglow/bgen/BigBgenDatasource.scala
+++ b/core/src/main/scala/io/projectglow/bgen/BigBgenDatasource.scala
@@ -44,7 +44,7 @@ object BigBgenDatasource extends HlsEventRecorder {
 
   import io.projectglow.common.BgenOptions._
 
-  def parseOptions(options: Map[String, String]): BigBgenOptions = {
+  private def parseOptions(options: Map[String, String]): BigBgenOptions = {
     val bitsPerProb = options.getOrElse(BITS_PER_PROB_KEY, BITS_PER_PROB_DEFAULT_VALUE).toInt
     val maxPloidy = options.getOrElse(MAX_PLOIDY_KEY, MAX_PLOIDY_VALUE).toInt
     val defaultPloidy = options.getOrElse(DEFAULT_PLOIDY_KEY, DEFAULT_PLOIDY_VALUE).toInt
@@ -52,7 +52,7 @@ object BigBgenDatasource extends HlsEventRecorder {
     BigBgenOptions(bitsPerProb, maxPloidy, defaultPloidy, defaultPhasing)
   }
 
-  def logWrite(parsedOptions: BigBgenOptions): Unit = {
+  private def logWrite(parsedOptions: BigBgenOptions): Unit = {
     val logOptions = Map(
       BITS_PER_PROB_KEY -> parsedOptions.bitsPerProb,
       MAX_PLOIDY_KEY -> parsedOptions.maxPloidy,

--- a/core/src/main/scala/io/projectglow/common/logging/HlsEventRecorder.scala
+++ b/core/src/main/scala/io/projectglow/common/logging/HlsEventRecorder.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectglow.common.logging
+
+// Simplifying wrapper around HlsUsageLogging
+trait HlsEventRecorder extends HlsUsageLogging {
+
+  protected def recordHlsEvent(tag: String, options: Map[String, Any]): Unit = {
+    val metric = HlsMetricDefinitions.EVENT_HLS_USAGE
+    recordHlsUsage(
+      metric,
+      Map(HlsTagDefinitions.TAG_EVENT_TYPE -> tag),
+      blob = hlsJsonBuilder(options))
+  }
+
+}

--- a/core/src/main/scala/io/projectglow/common/logging/HlsEventRecorder.scala
+++ b/core/src/main/scala/io/projectglow/common/logging/HlsEventRecorder.scala
@@ -19,11 +19,15 @@ package io.projectglow.common.logging
 trait HlsEventRecorder extends HlsUsageLogging {
 
   // Wrapper to simplify recording an HLS usage event
-  def recordHlsEvent(tag: String, options: Map[String, Any]): Unit = {
-    recordHlsUsage(
-      HlsMetricDefinitions.EVENT_HLS_USAGE,
-      Map(HlsTagDefinitions.TAG_EVENT_TYPE -> tag),
-      blob = hlsJsonBuilder(options))
+  def recordHlsEvent(tag: String, options: Map[String, Any] = Map.empty): Unit = {
+    val metric = HlsMetricDefinitions.EVENT_HLS_USAGE
+    val tags = Map(HlsTagDefinitions.TAG_EVENT_TYPE -> tag)
+
+    if (options.isEmpty) {
+      recordHlsUsage(metric, tags)
+    } else {
+      recordHlsUsage(metric, tags, blob = hlsJsonBuilder(options))
+    }
   }
 
 }

--- a/core/src/main/scala/io/projectglow/common/logging/HlsEventRecorder.scala
+++ b/core/src/main/scala/io/projectglow/common/logging/HlsEventRecorder.scala
@@ -19,10 +19,9 @@ package io.projectglow.common.logging
 // Simplifying wrapper around HlsUsageLogging
 trait HlsEventRecorder extends HlsUsageLogging {
 
-  protected def recordHlsEvent(tag: String, options: Map[String, Any]): Unit = {
-    val metric = HlsMetricDefinitions.EVENT_HLS_USAGE
+  def recordHlsEvent(tag: String, options: Map[String, Any]): Unit = {
     recordHlsUsage(
-      metric,
+      HlsMetricDefinitions.EVENT_HLS_USAGE,
       Map(HlsTagDefinitions.TAG_EVENT_TYPE -> tag),
       blob = hlsJsonBuilder(options))
   }

--- a/core/src/main/scala/io/projectglow/common/logging/HlsEventRecorder.scala
+++ b/core/src/main/scala/io/projectglow/common/logging/HlsEventRecorder.scala
@@ -16,9 +16,9 @@
 
 package io.projectglow.common.logging
 
-// Simplifying wrapper around HlsUsageLogging
 trait HlsEventRecorder extends HlsUsageLogging {
 
+  // Wrapper to simplify recording an HLS usage event
   def recordHlsEvent(tag: String, options: Map[String, Any]): Unit = {
     recordHlsUsage(
       HlsMetricDefinitions.EVENT_HLS_USAGE,

--- a/core/src/main/scala/io/projectglow/plink/PlinkFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/plink/PlinkFileFormat.scala
@@ -17,6 +17,7 @@
 package io.projectglow.plink
 
 import scala.collection.JavaConverters._
+
 import com.google.common.io.LittleEndianDataInputStream
 import com.univocity.parsers.csv.CsvParser
 import org.apache.commons.io.IOUtils
@@ -34,6 +35,7 @@ import org.apache.spark.sql.execution.datasources.csv.{CSVOptions, CSVUtils, Uni
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.{StructField, StructType}
+
 import io.projectglow.common.{CommonOptions, GlowLogging, VariantSchemas}
 import io.projectglow.common.logging.{HlsEventRecorder, HlsTagValues}
 import io.projectglow.sql.util.SerializableConfiguration
@@ -145,6 +147,7 @@ object PlinkFileFormat extends HlsEventRecorder {
   val MAGIC_BYTES: Seq[Byte] = Seq(0x6c, 0x1b, 0x01).map(_.toByte)
   val NUM_MAGIC_BYTES: Int = MAGIC_BYTES.size
 
+  /* Log that PLINK files are being read */
   def logPlinkRead(options: Map[String, String]): Unit = {
     val logOptions = Map(
       CommonOptions.INCLUDE_SAMPLE_IDS -> options

--- a/core/src/main/scala/io/projectglow/plink/PlinkFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/plink/PlinkFileFormat.scala
@@ -17,7 +17,6 @@
 package io.projectglow.plink
 
 import scala.collection.JavaConverters._
-
 import com.google.common.io.LittleEndianDataInputStream
 import com.univocity.parsers.csv.CsvParser
 import org.apache.commons.io.IOUtils
@@ -35,9 +34,8 @@ import org.apache.spark.sql.execution.datasources.csv.{CSVOptions, CSVUtils, Uni
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types.{StructField, StructType}
-
 import io.projectglow.common.{CommonOptions, GlowLogging, VariantSchemas}
-import io.projectglow.common.logging.{HlsMetricDefinitions, HlsTagDefinitions, HlsTagValues, HlsUsageLogging}
+import io.projectglow.common.logging.{HlsEventRecorder, HlsTagValues}
 import io.projectglow.sql.util.SerializableConfiguration
 
 class PlinkFileFormat
@@ -134,7 +132,7 @@ class PlinkFileFormat
   }
 }
 
-object PlinkFileFormat extends HlsUsageLogging {
+object PlinkFileFormat extends HlsEventRecorder {
 
   import io.projectglow.common.VariantSchemas._
   import io.projectglow.common.PlinkOptions._
@@ -146,6 +144,16 @@ object PlinkFileFormat extends HlsUsageLogging {
   val BLOCKS_PER_BYTE = 4
   val MAGIC_BYTES: Seq[Byte] = Seq(0x6c, 0x1b, 0x01).map(_.toByte)
   val NUM_MAGIC_BYTES: Int = MAGIC_BYTES.size
+
+  def logPlinkRead(options: Map[String, String]): Unit = {
+    val logOptions = Map(
+      CommonOptions.INCLUDE_SAMPLE_IDS -> options
+        .get(CommonOptions.INCLUDE_SAMPLE_IDS)
+        .forall(_.toBoolean),
+      MERGE_FID_IID -> options.get(CommonOptions.INCLUDE_SAMPLE_IDS).forall(_.toBoolean)
+    )
+    recordHlsEvent(HlsTagValues.EVENT_PLINK_READ, logOptions)
+  }
 
   /* Gets the BED path's prefix as the FAM and BIM path prefix  */
   def getPrefixPath(bedPath: String): String = {
@@ -278,23 +286,6 @@ object PlinkFileFormat extends HlsUsageLogging {
     require(
       magicNumber == MAGIC_BYTES,
       s"Magic bytes were not $hexString; this is not a variant-major BED."
-    )
-  }
-
-  /* Log that PLINK files are being read */
-  def logPlinkRead(options: Map[String, String]): Unit = {
-    val logOptions = Map(
-      CommonOptions.INCLUDE_SAMPLE_IDS -> options
-        .get(CommonOptions.INCLUDE_SAMPLE_IDS)
-        .forall(_.toBoolean),
-      MERGE_FID_IID -> options.get(CommonOptions.INCLUDE_SAMPLE_IDS).forall(_.toBoolean)
-    )
-    recordHlsUsage(
-      HlsMetricDefinitions.EVENT_HLS_USAGE,
-      Map(
-        HlsTagDefinitions.TAG_EVENT_TYPE -> HlsTagValues.EVENT_PLINK_READ
-      ),
-      blob = hlsJsonBuilder(logOptions)
     )
   }
 

--- a/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
+++ b/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
@@ -20,12 +20,14 @@ import java.net.URI
 import java.util.ServiceLoader
 
 import scala.collection.JavaConverters._
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
+
 import io.projectglow.common.{GlowLogging, WithUtils}
 
 /**

--- a/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
+++ b/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
@@ -20,14 +20,12 @@ import java.net.URI
 import java.util.ServiceLoader
 
 import scala.collection.JavaConverters._
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
-
 import io.projectglow.common.{GlowLogging, WithUtils}
 
 /**

--- a/core/src/main/scala/io/projectglow/transformers/normalizevariants/NormalizeVariantsTransformer.scala
+++ b/core/src/main/scala/io/projectglow/transformers/normalizevariants/NormalizeVariantsTransformer.scala
@@ -20,7 +20,7 @@ import htsjdk.samtools.ValidationStringency
 import org.apache.spark.sql.DataFrame
 
 import io.projectglow.DataFrameTransformer
-import io.projectglow.common.logging.{HlsMetricDefinitions, HlsTagDefinitions, HlsTagValues, HlsUsageLogging}
+import io.projectglow.common.logging.{HlsEventRecorder, HlsTagValues}
 import io.projectglow.transformers.util.StringUtils
 import io.projectglow.vcf.VCFOptionParser
 
@@ -39,7 +39,7 @@ import io.projectglow.vcf.VCFOptionParser
  * A path to reference genome containing .fasta, .fasta.fai, and .dict files must be provided
  * through the referenceGenomePath option.
  */
-class NormalizeVariantsTransformer extends DataFrameTransformer with HlsUsageLogging {
+class NormalizeVariantsTransformer extends DataFrameTransformer {
 
   override def name: String = "normalize_variants"
 
@@ -55,7 +55,6 @@ class NormalizeVariantsTransformer extends DataFrameTransformer with HlsUsageLog
       case Some(MODE_SPLIT) =>
         // record variantnormalizer event along with its mode
         logNormalizeVariants(MODE_SPLIT)
-
         VariantNormalizer.normalize(
           df,
           None,
@@ -67,7 +66,6 @@ class NormalizeVariantsTransformer extends DataFrameTransformer with HlsUsageLog
       case Some(MODE_SPLIT_NORMALIZE) =>
         // record variantnormalizer event along with its mode
         logNormalizeVariants(MODE_SPLIT_NORMALIZE)
-
         VariantNormalizer.normalize(
           df,
           options.get(REFERENCE_GENOME_PATH),
@@ -79,7 +77,6 @@ class NormalizeVariantsTransformer extends DataFrameTransformer with HlsUsageLog
       case Some(MODE_NORMALIZE) | None =>
         // record variantnormalizer event along with its mode
         logNormalizeVariants(MODE_NORMALIZE)
-
         VariantNormalizer.normalize(
           df,
           options.get(REFERENCE_GENOME_PATH),
@@ -94,21 +91,14 @@ class NormalizeVariantsTransformer extends DataFrameTransformer with HlsUsageLog
   }
 }
 
-object NormalizeVariantsTransformer extends HlsUsageLogging {
+object NormalizeVariantsTransformer extends HlsEventRecorder {
   val MODE_KEY = "mode"
   val MODE_NORMALIZE = "normalize"
   val MODE_SPLIT_NORMALIZE = "split_and_normalize"
   val MODE_SPLIT = "split"
   private val REFERENCE_GENOME_PATH = "reference_genome_path"
 
-  private[projectglow] def logNormalizeVariants(mode: String): Unit = {
-    val logOptions = Map(MODE_KEY -> mode)
-    recordHlsUsage(
-      HlsMetricDefinitions.EVENT_HLS_USAGE,
-      Map(
-        HlsTagDefinitions.TAG_EVENT_TYPE -> HlsTagValues.EVENT_NORMALIZE_VARIANTS
-      ),
-      blob = hlsJsonBuilder(logOptions)
-    )
+  def logNormalizeVariants(mode: String): Unit = {
+    recordHlsEvent(HlsTagValues.EVENT_NORMALIZE_VARIANTS, Map(MODE_KEY -> mode))
   }
 }

--- a/core/src/main/scala/io/projectglow/transformers/normalizevariants/NormalizeVariantsTransformer.scala
+++ b/core/src/main/scala/io/projectglow/transformers/normalizevariants/NormalizeVariantsTransformer.scala
@@ -54,7 +54,7 @@ class NormalizeVariantsTransformer extends DataFrameTransformer {
 
       case Some(MODE_SPLIT) =>
         // record variantnormalizer event along with its mode
-        logNormalizeVariants(MODE_SPLIT)
+        recordHlsEvent(HlsTagValues.EVENT_NORMALIZE_VARIANTS, Map(MODE_KEY -> MODE_SPLIT))
         VariantNormalizer.normalize(
           df,
           None,
@@ -65,7 +65,7 @@ class NormalizeVariantsTransformer extends DataFrameTransformer {
 
       case Some(MODE_SPLIT_NORMALIZE) =>
         // record variantnormalizer event along with its mode
-        logNormalizeVariants(MODE_SPLIT_NORMALIZE)
+        recordHlsEvent(HlsTagValues.EVENT_NORMALIZE_VARIANTS, Map(MODE_KEY -> MODE_SPLIT_NORMALIZE))
         VariantNormalizer.normalize(
           df,
           options.get(REFERENCE_GENOME_PATH),
@@ -76,7 +76,7 @@ class NormalizeVariantsTransformer extends DataFrameTransformer {
 
       case Some(MODE_NORMALIZE) | None =>
         // record variantnormalizer event along with its mode
-        logNormalizeVariants(MODE_NORMALIZE)
+        recordHlsEvent(HlsTagValues.EVENT_NORMALIZE_VARIANTS, Map(MODE_KEY -> MODE_NORMALIZE))
         VariantNormalizer.normalize(
           df,
           options.get(REFERENCE_GENOME_PATH),
@@ -97,8 +97,4 @@ object NormalizeVariantsTransformer extends HlsEventRecorder {
   val MODE_SPLIT_NORMALIZE = "split_and_normalize"
   val MODE_SPLIT = "split"
   private val REFERENCE_GENOME_PATH = "reference_genome_path"
-
-  def logNormalizeVariants(mode: String): Unit = {
-    recordHlsEvent(HlsTagValues.EVENT_NORMALIZE_VARIANTS, Map(MODE_KEY -> mode))
-  }
 }

--- a/core/src/main/scala/io/projectglow/transformers/pipe/PipeTransformer.scala
+++ b/core/src/main/scala/io/projectglow/transformers/pipe/PipeTransformer.scala
@@ -31,7 +31,7 @@ import io.projectglow.common.Named
 import io.projectglow.common.logging._
 import io.projectglow.transformers.util.SnakeCaseMap
 
-class PipeTransformer extends DataFrameTransformer with HlsUsageLogging {
+class PipeTransformer extends DataFrameTransformer {
   override def name: String = "pipe"
 
   override def transform(df: DataFrame, options: Map[String, String]): DataFrame = {
@@ -39,7 +39,8 @@ class PipeTransformer extends DataFrameTransformer with HlsUsageLogging {
   }
 
   // Implementation is in an inner class to avoid passing options to private methods
-  private class PipeTransformerImpl(df: DataFrame, options: Map[String, String]) {
+  private class PipeTransformerImpl(df: DataFrame, options: Map[String, String])
+      extends HlsEventRecorder {
 
     import PipeTransformer._
 
@@ -83,8 +84,8 @@ class PipeTransformer extends DataFrameTransformer with HlsUsageLogging {
       mapper.readValue(str, classOf[Seq[String]])
     }
 
-    def transform(): DataFrame = {
-
+    private val loggingOptions: Map[String, Any] = {
+      // TODO: More tools to be added
       val pipeToolSet = Array(
         "saige",
         "plink",
@@ -94,16 +95,12 @@ class PipeTransformer extends DataFrameTransformer with HlsUsageLogging {
         "cat"
       )
 
-      val cmd = getCmd
-
-      // record the pipe event along with tools of interest which maybe called using it.
-      // TODO: More tools to be added
-      val toolInPipe = Map(
+      Map(
         LOGGING_BLOB_KEY ->
         pipeToolSet
           .foldLeft(Array[String]())(
             (a, b: String) =>
-              if (cmd.exists(_.toLowerCase.contains(b))) {
+              if (getCmd.exists(_.toLowerCase.contains(b))) {
                 a :+ b
               } else {
                 a
@@ -111,15 +108,13 @@ class PipeTransformer extends DataFrameTransformer with HlsUsageLogging {
           )
           .mkString(",")
       )
+    }
 
-      recordHlsUsage(
-        HlsMetricDefinitions.EVENT_HLS_USAGE,
-        Map(
-          HlsTagDefinitions.TAG_EVENT_TYPE -> HlsTagValues.EVENT_PIPE
-        ),
-        blob = hlsJsonBuilder(toolInPipe)
-      )
+    def transform(): DataFrame = {
+      // record the pipe event along with tools of interest which maybe called using it.
+      recordHlsEvent(HlsTagValues.EVENT_PIPE, loggingOptions)
 
+      val cmd = getCmd
       val inputFormatter = getInputFormatter
       val outputFormatter = getOutputFormatter
       val env = options.collect {

--- a/core/src/main/scala/io/projectglow/transformers/pipe/PipeTransformer.scala
+++ b/core/src/main/scala/io/projectglow/transformers/pipe/PipeTransformer.scala
@@ -100,7 +100,7 @@ class PipeTransformer extends DataFrameTransformer {
         pipeToolSet
           .foldLeft(Array[String]())(
             (a, b: String) =>
-              if (getCmd.exists(_.toLowerCase.contains(b))) {
+              if (cmd.exists(_.toLowerCase.contains(b))) {
                 a :+ b
               } else {
                 a

--- a/core/src/main/scala/io/projectglow/transformers/pipe/PipeTransformer.scala
+++ b/core/src/main/scala/io/projectglow/transformers/pipe/PipeTransformer.scala
@@ -84,7 +84,7 @@ class PipeTransformer extends DataFrameTransformer {
       mapper.readValue(str, classOf[Seq[String]])
     }
 
-    private val loggingOptions: Map[String, Any] = {
+    private def getLogOptions(cmd: Seq[String]): Map[String, Any] = {
       // TODO: More tools to be added
       val pipeToolSet = Array(
         "saige",
@@ -111,10 +111,11 @@ class PipeTransformer extends DataFrameTransformer {
     }
 
     def transform(): DataFrame = {
-      // record the pipe event along with tools of interest which maybe called using it.
-      recordHlsEvent(HlsTagValues.EVENT_PIPE, loggingOptions)
-
       val cmd = getCmd
+
+      // record the pipe event along with tools of interest which maybe called using it.
+      recordHlsEvent(HlsTagValues.EVENT_PIPE, getLogOptions(cmd))
+
       val inputFormatter = getInputFormatter
       val outputFormatter = getOutputFormatter
       val env = options.collect {

--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -47,7 +47,7 @@ object BigVCFDatasource extends HlsEventRecorder {
 
   def serializeDataFrame(options: Map[String, String], data: DataFrame): RDD[Array[Byte]] = {
 
-    recordHlsEvent(HlsTagValues.EVENT_BIGVCF_WRITE, Map.empty)
+    recordHlsEvent(HlsTagValues.EVENT_BIGVCF_WRITE)
 
     val schema = data.schema
     val rdd = data.queryExecution.toRdd

--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -18,7 +18,6 @@ package io.projectglow.vcf
 
 import java.io.ByteArrayOutputStream
 
-import io.projectglow.common.logging.{HlsEventRecorder, HlsTagValues}
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.io.compress.CompressionCodecFactory
 import org.apache.spark.rdd.RDD
@@ -26,6 +25,8 @@ import org.apache.spark.SparkException
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.sources.DataSourceRegister
 import org.seqdoop.hadoop_bam.util.DatabricksBGZFOutputStream
+
+import io.projectglow.common.logging.{HlsEventRecorder, HlsTagValues}
 import io.projectglow.sql.BigFileDatasource
 import io.projectglow.sql.util.{ComDatabricksDataSource, SerializableConfiguration}
 

--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -46,7 +46,7 @@ object BigVCFDatasource extends HlsEventRecorder {
 
   def serializeDataFrame(options: Map[String, String], data: DataFrame): RDD[Array[Byte]] = {
 
-    recordHlsEvent(HlsTagValues.EVENT_BGEN_WRITE, Map.empty)
+    recordHlsEvent(HlsTagValues.EVENT_BIGVCF_WRITE, Map.empty)
 
     val schema = data.schema
     val rdd = data.queryExecution.toRdd


### PR DESCRIPTION
## What changes are proposed in this pull request?

Ensures that we only log one big VCF write per file, not per partition. For ease of use down the road, also simplifies the logging interface.

## How is this patch tested?
- [ ] Unit tests
- [x] Integration tests
- [ ] Manual tests

Events are propagated on the universe side.