### PR TITLE
Make annotation column names safe

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/AnnotationUtils.scala
+++ b/core/src/main/scala/io/projectglow/vcf/AnnotationUtils.scala
@@ -44,9 +44,9 @@ object AnnotationUtils {
   private val snpEffFieldsToSchema: Map[String, DataType] = Map(
     "Annotation" -> ArrayType(StringType),
     "Rank" -> rankTotalStruct,
-    "cDNA.pos / cDNA.length" -> posLengthStruct,
-    "CDS.pos / CDS.length" -> posLengthStruct,
-    "AA.pos / AA.length" -> posLengthStruct,
+    "cDNA_pos/cDNA_length" -> posLengthStruct,
+    "CDS_pos/CDS_length" -> posLengthStruct,
+    "AA_pos/AA_length" -> posLengthStruct,
     "Distance" -> IntegerType
   )
 

--- a/core/src/main/scala/io/projectglow/vcf/VCFSchemaInferrer.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFSchemaInferrer.scala
@@ -279,9 +279,9 @@ object VCFSchemaInferrer {
       .split(AnnotationUtils.annotationDelimiterRegex)
 
     Seq(ArrayType(StructType(fieldNames.map { f =>
-      val trimmedFieldName = f.trim()
-      val dataType = AnnotationUtils.allFieldsToSchema(trimmedFieldName)
-      StructField(trimmedFieldName, dataType)
+      val safeFieldName = f.replace(" ", "").replace(".", "_")
+      val dataType = AnnotationUtils.allFieldsToSchema(safeFieldName)
+      StructField(safeFieldName, dataType)
     })))
   }
 

--- a/core/src/test/scala/io/projectglow/vcf/VCFSchemaInferrerSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFSchemaInferrerSuite.scala
@@ -311,19 +311,19 @@ class VCFSchemaInferrerSuite extends GlowBaseTest {
         StructField(
           "Rank",
           StructType(Seq(StructField("rank", IntegerType), StructField("total", IntegerType)))),
-        StructField("HGVS.c", StringType),
-        StructField("HGVS.p", StringType),
+        StructField("HGVS_c", StringType),
+        StructField("HGVS_p", StringType),
         StructField(
-          "cDNA.pos / cDNA.length",
+          "cDNA_pos/cDNA_length",
           StructType(Seq(StructField("pos", IntegerType), StructField("length", IntegerType)))),
         StructField(
-          "CDS.pos / CDS.length",
+          "CDS_pos/CDS_length",
           StructType(Seq(StructField("pos", IntegerType), StructField("length", IntegerType)))),
         StructField(
-          "AA.pos / AA.length",
+          "AA_pos/AA_length",
           StructType(Seq(StructField("pos", IntegerType), StructField("length", IntegerType)))),
         StructField("Distance", IntegerType),
-        StructField("ERRORS / WARNINGS / INFO", StringType)
+        StructField("ERRORS/WARNINGS/INFO", StringType)
       ))))
 
     val inferredHeaderLines = VCFSchemaInferrer.headerLinesFromSchema(inferredSchema)


### PR DESCRIPTION
## What changes are proposed in this pull request?

The annotation subfields parsed from `ANN` by https://github.com/projectglow/glow/pull/122 are unsafe to save to Parquet, as they may contain illegal characters (such as spaces). This PR removes spaces and dots (to keep them from being parsed as structs) from any subfield names to make them safe to save.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests