### PR TITLE
Fix large PLINK file ingest

### DIFF
--- a/core/src/main/scala/io/projectglow/plink/PlinkFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/plink/PlinkFileFormat.scala
@@ -265,15 +265,15 @@ object PlinkFileFormat extends HlsEventRecorder {
   }
 
   /* The location of the first byte for a variant in a BED */
-  def getVariantStart(variantIdx: Int, blockSize: Int): Int = {
-    NUM_MAGIC_BYTES + (blockSize * variantIdx)
+  def getVariantStart(variantIdx: Int, blockSize: Int): Long = {
+    NUM_MAGIC_BYTES + (blockSize * variantIdx.toLong)
   }
 
   /* Number of variants to be read from a partitioned BED */
   def getNumVariants(
       partitionedFileStart: Long,
       partitionedFileLength: Long,
-      firstVariantStart: Int,
+      firstVariantStart: Long,
       blockSize: Int): Int = {
     val actualLength = partitionedFileLength - (firstVariantStart - partitionedFileStart)
     math.ceil(actualLength / blockSize.toDouble).toInt

--- a/core/src/test/scala/io/projectglow/plink/PlinkReaderSuite.scala
+++ b/core/src/test/scala/io/projectglow/plink/PlinkReaderSuite.scala
@@ -327,7 +327,7 @@ class PlinkReaderSuite extends GlowBaseTest {
     assert(!schema.exists(_.name == "sampleId"))
   }
 
-  def getVariantIdxStartNum(fileStart: Long, fileLength: Long, blockSize: Int): (Int, Int, Int) = {
+  def getVariantIdxStartNum(fileStart: Long, fileLength: Long, blockSize: Int): (Int, Long, Int) = {
     val firstVariantIdx = PlinkFileFormat.getFirstVariantIdx(fileStart, blockSize)
     val firstVariantStart = PlinkFileFormat.getVariantStart(firstVariantIdx, blockSize)
     val numVariants =
@@ -370,6 +370,16 @@ class PlinkReaderSuite extends GlowBaseTest {
     (5 to 8).foreach { s =>
       assert(PlinkFileFormat.getBlockSize(s) == 2)
     }
+  }
+
+  test("Big PLINK files") {
+    val num1KgSamples = 2504
+    val blockSize = PlinkFileFormat.getBlockSize(num1KgSamples)
+    assert(blockSize == 626)
+
+    val variantIdx = 25484379
+    val variantStart = PlinkFileFormat.getVariantStart(variantIdx, blockSize)
+    assert(variantStart == 15953221257L)
   }
 
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Calculates the byte location for a variant in a (PLINK) BED file as a `Long` to avoid integer overflow.
Addresses https://github.com/projectglow/glow/issues/133.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

Successfully ran through the workflow described in the aforementioned issue.
