### PR TITLE
Speed up PLINK read

### DIFF
--- a/core/src/main/scala/io/projectglow/plink/PlinkRowToInternalRowConverter.scala
+++ b/core/src/main/scala/io/projectglow/plink/PlinkRowToInternalRowConverter.scala
@@ -65,11 +65,8 @@ class PlinkRowToInternalRowConverter(schema: StructType) extends GlowLogging {
             }
             r.update(i, new GenericArrayData(genotypes))
           }
-        case f =>
-          logger.info(
-            s"Column $f cannot be derived from PLINK records. It will be null for each " +
-            s"row."
-          )
+        case _ =>
+          // BED file only contains genotypes
           (_, _, _) => ()
       }
       fn

--- a/core/src/main/scala/io/projectglow/plink/PlinkRowToInternalRowConverter.scala
+++ b/core/src/main/scala/io/projectglow/plink/PlinkRowToInternalRowConverter.scala
@@ -48,7 +48,7 @@ class PlinkRowToInternalRowConverter(schema: StructType) extends GlowLogging {
 
   private val converter = {
     val fns = schema.map { field =>
-      val fn: RowConverter.Updater[(Array[String], Array[Byte])] = field match {
+      val fn: RowConverter.Updater[(Array[UTF8String], Array[Byte])] = field match {
         case f if f.name == VariantSchemas.genotypesFieldName =>
           val gSchema = f.dataType.asInstanceOf[ArrayType].elementType.asInstanceOf[StructType]
           val converter = makeGenotypeConverter(gSchema)
@@ -74,15 +74,15 @@ class PlinkRowToInternalRowConverter(schema: StructType) extends GlowLogging {
       }
       fn
     }
-    new RowConverter[(Array[String], Array[Byte])](schema, fns.toArray)
+    new RowConverter[(Array[UTF8String], Array[Byte])](schema, fns.toArray)
   }
 
-  private def makeGenotypeConverter(gSchema: StructType): RowConverter[(String, Int)] = {
+  private def makeGenotypeConverter(gSchema: StructType): RowConverter[(UTF8String, Int)] = {
     val functions = gSchema.map { field =>
-      val fn: RowConverter.Updater[(String, Int)] = field match {
+      val fn: RowConverter.Updater[(UTF8String, Int)] = field match {
         case f if structFieldsEqualExceptNullability(f, VariantSchemas.sampleIdField) =>
           (sampleAndTwoBits, r, i) => {
-            r.update(i, UTF8String.fromString(sampleAndTwoBits._1))
+            r.update(i, sampleAndTwoBits._1)
           }
         case f if structFieldsEqualExceptNullability(f, VariantSchemas.callsField) =>
           (sampleAndTwoBits, r, i) => r.update(i, twoBitsToCalls(sampleAndTwoBits._2))
@@ -95,12 +95,12 @@ class PlinkRowToInternalRowConverter(schema: StructType) extends GlowLogging {
       }
       fn
     }
-    new RowConverter[(String, Int)](gSchema, functions.toArray)
+    new RowConverter[(UTF8String, Int)](gSchema, functions.toArray)
   }
 
   def convertRow(
       bimRow: InternalRow,
-      sampleIds: Array[String],
+      sampleIds: Array[UTF8String],
       gtBlock: Array[Byte]): InternalRow = {
     converter((sampleIds, gtBlock), bimRow)
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Speeds up PLINK read by only converting the sample IDs to `UTF8String`s once, rather than for each genotype.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

On the same cluster setup, I read from the 1KG PLINK files and materialized the DataFrame (by writing to a `noop` format). This change resulted in the runtime decreasing from 1.76 minutes to 1.18 minutes.