### PR TITLE
Fix VCF output formatter

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/VCFOutputFormatter.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFOutputFormatter.scala
@@ -50,7 +50,7 @@ class VCFOutputFormatter(stringency: ValidationStringency)
         while (nextRecord == null && lineIterator.hasNext) {
           val decoded = codec.decode(lineIterator.next())
           if (decoded != null) {
-            nextRecord = projection(converter.convertRow(decoded, isSplit = false))
+            nextRecord = projection(converter.convertRow(decoded, isSplit = false)).copy()
           }
         }
       }

--- a/core/src/test/scala/io/projectglow/vcf/VCFPiperSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFPiperSuite.scala
@@ -77,6 +77,13 @@ class VCFPiperSuite extends GlowBaseTest {
     (inputDf, outputDf)
   }
 
+  test("Cat") {
+    val (inputDf, outputDf) = pipeScript(na12878, "cat")
+    val inputRows = inputDf.collect().toSeq
+    val outputRows = outputDf.collect().toSeq
+    assert(inputRows == outputRows)
+  }
+
   test("Prepend chr") {
     val (_, df) = pipeScript(
       na12878,


### PR DESCRIPTION
## What changes are proposed in this pull request?

We broke the VCF output formatter in https://github.com/projectglow/glow/pull/79 by not copying the unsafe rows; this resulted in each row of VCF output from the pipe transformer being equivalent.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

Added sanity check for VCF piper.