### PR TITLE
Prepare for Spark 3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -160,6 +160,8 @@ lazy val core = (project in file("core"))
     Package.ManifestAttributes("Git-Release-Hash" -> currentGitHash(baseDirectory.value)),
     bintrayRepository := "glow",
     libraryDependencies ++= coreDependencies,
+    Compile / unmanagedSourceDirectories += baseDirectory.value / "src" / "main" / "shim" / "2.4",
+    Test / unmanagedSourceDirectories += baseDirectory.value / "src" / "test" / "shim" / "2.4",
     sourceGenerators in Compile += Def.task {
       val file = baseDirectory.value / "functions.scala.TEMPLATE"
       val output = (Compile / scalaSource).value / "io" / "projectglow" / "functions.scala"

--- a/core/src/main/scala/io/projectglow/SparkShimBase.scala
+++ b/core/src/main/scala/io/projectglow/SparkShimBase.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectglow
+
+import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
+
+trait SparkShimBase {
+  type CSVOptions
+  type UnivocityParser
+
+  def createExpressionInfo(
+      className: String,
+      db: String,
+      name: String,
+      usage: String,
+      arguments: String,
+      examples: String,
+      note: String,
+      since: String): ExpressionInfo
+}

--- a/core/src/main/scala/io/projectglow/SparkShimBase.scala
+++ b/core/src/main/scala/io/projectglow/SparkShimBase.scala
@@ -18,6 +18,7 @@ package io.projectglow
 
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 
+// Spark APIs that are not inter-version compatible
 trait SparkShimBase {
   type CSVOptions
   type UnivocityParser

--- a/core/src/main/scala/io/projectglow/sql/SqlExtensionProvider.scala
+++ b/core/src/main/scala/io/projectglow/sql/SqlExtensionProvider.scala
@@ -23,12 +23,13 @@ import scala.collection.JavaConverters._
 import org.apache.spark.sql.{SQLUtils, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
-import org.apache.spark.sql.catalyst.expressions.{Expression, ExpressionInfo}
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.internal.SQLConf
 import org.yaml.snakeyaml.Yaml
 
+import io.projectglow.SparkShim._
 import io.projectglow.common.WithUtils
 import io.projectglow.sql.expressions._
 import io.projectglow.sql.optimizer.{ReplaceExpressionsRule, ResolveAggregateFunctionsRule}
@@ -51,33 +52,47 @@ class GlowSQLExtensions extends (SparkSessionExtensions => Unit) {
 object SqlExtensionProvider {
   private val FUNCTION_YAML_PATH = "functions.yml"
 
-  private def loadFunctionDefinitions(resourcePath: String): Iterable[JMap[String, Any]] = {
+  private def loadFunctionDefinitions(
+      resourcePath: String
+  ): Iterable[JMap[String, Any]] = {
     val yml = new Yaml()
     WithUtils.withCloseable(
-      Thread.currentThread().getContextClassLoader.getResourceAsStream(resourcePath)) { stream =>
+      Thread
+        .currentThread()
+        .getContextClassLoader
+        .getResourceAsStream(resourcePath)
+    ) { stream =>
       val groups = yml.loadAs(stream, classOf[JMap[String, JMap[String, Any]]])
       groups
         .values()
         .asScala
-        .flatMap(group => group.asScala("functions").asInstanceOf[JList[JMap[String, Any]]].asScala)
+        .flatMap(
+          group =>
+            group
+              .asScala("functions")
+              .asInstanceOf[JList[JMap[String, Any]]]
+              .asScala
+        )
     }
   }
 
   private def parameterError(functionName: String, params: Int): Exception = {
     SQLUtils.newAnalysisException(
-      s"Invalid number of parameters for function '$functionName': $params")
+      s"Invalid number of parameters for function '$functionName': $params"
+    )
   }
 
   private def makeArgsDoc(args: Seq[JMap[String, Any]]): String = {
     args.map { _arg =>
       val arg = _arg.asScala
-      val suffix = if (arg.get("is_optional").exists(_.asInstanceOf[Boolean])) {
-        " (optional)"
-      } else if (arg.get("is_var_args").exists(_.asInstanceOf[Boolean])) {
-        " (repeated)"
-      } else {
-        ""
-      }
+      val suffix =
+        if (arg.get("is_optional").exists(_.asInstanceOf[Boolean])) {
+          " (optional)"
+        } else if (arg.get("is_var_args").exists(_.asInstanceOf[Boolean])) {
+          " (repeated)"
+        } else {
+          ""
+        }
       s"${arg("name")}: ${arg("doc")} $suffix"
     }.mkString("\n")
   }
@@ -95,7 +110,9 @@ object SqlExtensionProvider {
         val arg = _arg.asScala
         // If the argument is optional and doesn't have a matching input, don't add a new
         // expression to the list of children.
-        if (arg.get("is_optional").exists(_.asInstanceOf[Boolean]) && idx >= exprs.size) {
+        if (arg
+            .get("is_optional")
+            .exists(_.asInstanceOf[Boolean]) && idx >= exprs.size) {
           None
           // If we have a var args argument, the child expressions from here on are part of
           // the var args list.
@@ -124,7 +141,7 @@ object SqlExtensionProvider {
       val id = FunctionIdentifier(function("name").asInstanceOf[String])
       val exprClass = function("expr_class").asInstanceOf[String]
       val args = function("args").asInstanceOf[JList[JMap[String, Any]]].asScala
-      val info = new ExpressionInfo(
+      val info = createExpressionInfo(
         exprClass,
         null,
         function("name").asInstanceOf[String],
@@ -138,7 +155,11 @@ object SqlExtensionProvider {
         id,
         info,
         exprs => {
-          val clazz = Class.forName(exprClass, true, Thread.currentThread().getContextClassLoader)
+          val clazz = Class.forName(
+            exprClass,
+            true,
+            Thread.currentThread().getContextClassLoader
+          )
           val constructorArgs = makeChildren(id.funcName, args, exprs)
           val constructor = clazz
             .getConstructors
@@ -148,7 +169,8 @@ object SqlExtensionProvider {
           ExpressionHelper.rewrite(
             constructor
               .newInstance(constructorArgs: _*)
-              .asInstanceOf[Expression])
+              .asInstanceOf[Expression]
+          )
         }
       )
     }

--- a/core/src/main/scala/io/projectglow/transformers/pipe/CSVInputFormatter.scala
+++ b/core/src/main/scala/io/projectglow/transformers/pipe/CSVInputFormatter.scala
@@ -20,8 +20,10 @@ import java.io.{OutputStream, PrintWriter}
 
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.execution.datasources.csv.{CSVOptions, SGUnivocityGenerator}
+import org.apache.spark.sql.execution.datasources.csv.SGUnivocityGenerator
 import org.apache.spark.sql.types.StructType
+
+import io.projectglow.SparkShim.CSVOptions
 
 class CSVInputFormatter(schema: StructType, parsedOptions: CSVOptions) extends InputFormatter {
 
@@ -49,10 +51,17 @@ class CSVInputFormatter(schema: StructType, parsedOptions: CSVOptions) extends I
 class CSVInputFormatterFactory extends InputFormatterFactory {
   override def name: String = "csv"
 
-  override def makeInputFormatter(df: DataFrame, options: Map[String, String]): InputFormatter = {
+  override def makeInputFormatter(
+      df: DataFrame,
+      options: Map[String, String]
+  ): InputFormatter = {
     val sqlConf = df.sparkSession.sessionState.conf
     val parsedOptions =
-      new CSVOptions(options, sqlConf.csvColumnPruning, sqlConf.sessionLocalTimeZone)
+      new CSVOptions(
+        options,
+        sqlConf.csvColumnPruning,
+        sqlConf.sessionLocalTimeZone
+      )
     new CSVInputFormatter(df.schema, parsedOptions)
   }
 }

--- a/core/src/main/shim/2.4/SparkShim.scala
+++ b/core/src/main/shim/2.4/SparkShim.scala
@@ -18,6 +18,7 @@ package io.projectglow
 
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 
+// Spark 2.4 APIs that are not inter-version compatible
 object SparkShim extends SparkShimBase {
   override type CSVOptions = org.apache.spark.sql.execution.datasources.csv.CSVOptions
   override type UnivocityParser = org.apache.spark.sql.execution.datasources.csv.UnivocityParser

--- a/core/src/main/shim/2.4/SparkShim.scala
+++ b/core/src/main/shim/2.4/SparkShim.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectglow
+
+import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
+
+object SparkShim extends SparkShimBase {
+  override type CSVOptions = org.apache.spark.sql.execution.datasources.csv.CSVOptions
+  override type UnivocityParser = org.apache.spark.sql.execution.datasources.csv.UnivocityParser
+
+  override def createExpressionInfo(
+      className: String,
+      db: String,
+      name: String,
+      usage: String,
+      arguments: String,
+      examples: String,
+      note: String,
+      since: String): ExpressionInfo = {
+    new ExpressionInfo(
+      className,
+      db,
+      name,
+      usage,
+      arguments,
+      examples,
+      note,
+      since
+    )
+  }
+}

--- a/core/src/main/shim/3.0/SparkShim.scala
+++ b/core/src/main/shim/3.0/SparkShim.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectglow
+
+import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
+
+object SparkShim extends SparkShimBase {
+  override type CSVOptions = org.apache.spark.sql.catalyst.csv.CSVOptions
+  override type UnivocityParser = org.apache.spark.sql.catalyst.csv.UnivocityParser
+
+  override def createExpressionInfo(
+      className: String,
+      db: String,
+      name: String,
+      usage: String,
+      arguments: String,
+      examples: String,
+      note: String,
+      since: String): ExpressionInfo = {
+    new ExpressionInfo(
+      className,
+      db,
+      name,
+      usage,
+      arguments,
+      examples,
+      note,
+      since,
+      "" // deprecated
+    )
+  }
+}

--- a/core/src/main/shim/3.0/SparkShim.scala
+++ b/core/src/main/shim/3.0/SparkShim.scala
@@ -18,10 +18,15 @@ package io.projectglow
 
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 
+// Spark 3.0 APIs that are not inter-version compatible
 object SparkShim extends SparkShimBase {
+  // [SPARK-25393][SQL] Adding new function from_csv()
+  // Refactors classes from [[org.apache.spark.sql.execution.datasources.csv]] to [[org.apache.spark.sql.catalyst.csv]]
   override type CSVOptions = org.apache.spark.sql.catalyst.csv.CSVOptions
   override type UnivocityParser = org.apache.spark.sql.catalyst.csv.UnivocityParser
 
+  // [SPARK-27328][SQL] Add 'deprecated' in ExpressionDescription for extended usage and SQL doc
+  // Adds 'deprecated' argument to the ExpressionInfo constructor
   override def createExpressionInfo(
       className: String,
       db: String,

--- a/core/src/test/scala/io/projectglow/SparkTestShimBase.scala
+++ b/core/src/test/scala/io/projectglow/SparkTestShimBase.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectglow
+
+trait SparkTestShimBase {
+  type SharedSparkSessionBase
+}

--- a/core/src/test/scala/io/projectglow/SparkTestShimBase.scala
+++ b/core/src/test/scala/io/projectglow/SparkTestShimBase.scala
@@ -16,6 +16,7 @@
 
 package io.projectglow
 
+// Spark APIs that are not inter-version compatible
 trait SparkTestShimBase {
   type SharedSparkSessionBase
 }

--- a/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
+++ b/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
@@ -18,19 +18,19 @@ package io.projectglow.sql
 
 import htsjdk.samtools.util.Log
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.test.SharedSparkSession
 import org.apache.spark.{DebugFilesystem, SparkConf}
 import org.scalatest.concurrent.{AbstractPatienceConfiguration, Eventually}
 import org.scalatest.time.{Milliseconds, Seconds, Span}
 import org.scalatest.{Args, FunSuite, Status, Tag}
 
 import io.projectglow.Glow
+import io.projectglow.SparkTestShim.SharedSparkSessionBase
 import io.projectglow.common.{GlowLogging, TestUtils}
 import io.projectglow.sql.util.BGZFCodec
 
 abstract class GlowBaseTest
     extends FunSuite
-    with SharedSparkSession
+    with SharedSparkSessionBase
     with GlowLogging
     with GlowTestData
     with TestUtils

--- a/core/src/test/scala/io/projectglow/tertiary/AggregateByIndexSuite.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/AggregateByIndexSuite.scala
@@ -150,7 +150,8 @@ class AggregateByIndexSuite extends GlowBaseTest {
         """.stripMargin)
       .as[Seq[Int]]
       .head
-    assert(result == Seq.empty)
+    // null if Spark 3.0, empty list if Spark 2.4
+    assert(result == null || result == Seq.empty)
   }
 
   test("null array") {
@@ -166,6 +167,7 @@ class AggregateByIndexSuite extends GlowBaseTest {
         """.stripMargin)
       .as[Seq[Option[Int]]]
       .head
-    assert(result == Seq(None))
+    // Seq(Some(1)) if Spark 3.0, Seq(None) if Spark 2.4
+    assert(result == Seq(Some(1)) || result == Seq(None))
   }
 }

--- a/core/src/test/shim/2.4/SparkTestShim.scala
+++ b/core/src/test/shim/2.4/SparkTestShim.scala
@@ -16,6 +16,8 @@
 
 package io.projectglow
 
+// Spark 2.4 APIs that are not inter-version compatible
 object SparkTestShim extends SparkTestShimBase {
+  // Spark  renames SharedSparkSession to SharedSparkSessionBase
   override type SharedSparkSessionBase = org.apache.spark.sql.test.SharedSparkSession
 }

--- a/core/src/test/shim/2.4/SparkTestShim.scala
+++ b/core/src/test/shim/2.4/SparkTestShim.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectglow
+
+object SparkTestShim extends SparkTestShimBase {
+  override type SharedSparkSessionBase = org.apache.spark.sql.test.SharedSparkSession
+}

--- a/core/src/test/shim/3.0/SparkTestShim.scala
+++ b/core/src/test/shim/3.0/SparkTestShim.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectglow
+
+object SparkTestShim extends SparkTestShimBase {
+  override type SharedSparkSessionBase = org.apache.spark.sql.test.SharedSparkSessionBase
+}

--- a/core/src/test/shim/3.0/SparkTestShim.scala
+++ b/core/src/test/shim/3.0/SparkTestShim.scala
@@ -16,6 +16,9 @@
 
 package io.projectglow
 
+// Spark 3.0 APIs that are not inter-version compatible
 object SparkTestShim extends SparkTestShimBase {
+  // [SPARK-28744][SQL][TEST] rename SharedSQLContext to SharedSparkSession
+  // Renames SharedSparkSession to SharedSparkSessionBase
   override type SharedSparkSessionBase = org.apache.spark.sql.test.SharedSparkSessionBase
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Source code changes so that we are ready for Spark 3.0, which includes some internal API refactoring and [behavior changes](https://spark.apache.org/docs/3.0.0-preview/sql-migration-guide.html).

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

Confirmed tests (`core_2_12/test`, `python_2_12/test`, and `docs_2_12_test`) will pass on Spark 3.0, which is built on Scala 2.12. To build Glow on Spark 3.0, do the following: 

- Modify `build.sbt `
   + `val sparkVersion = "3.0.0-preview2"`
   + In `core`:
      - `Compile / unmanagedSourceDirectories += baseDirectory.value / "src" / "main" / "shim" / "3.0"`,
      - `Test / unmanagedSourceDirectories += baseDirectory.value / "src" / "test" / "shim" / "3.0"`,
- [Download](https://www.apache.org/dist/spark/spark-3.0.0-preview2/) and `pip install pyspark-3.0.0.dev2.tar.gz`