### PR TITLE
Aggregation signature rewrite

### DIFF
--- a/core/src/main/scala/io/projectglow/sql/optimizer/hlsOptimizerRules.scala
+++ b/core/src/main/scala/io/projectglow/sql/optimizer/hlsOptimizerRules.scala
@@ -65,7 +65,7 @@ object ResolveExpandStructRule extends Rule[LogicalPlan] {
     plan.resolveOperatorsUp {
       case p @ Project(projectList, _) if canExpand(projectList) =>
         p.copy(projectList = expandExprs(p.projectList))
-      case a @ Aggregate(_, aggregateExpressions, _) if canExpand(aggregateExpressions) =>
+      case a: Aggregate if canExpand(a.aggregateExpressions) =>
         a.copy(aggregateExpressions = expandExprs(a.aggregateExpressions))
     }
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?

`Aggregate` has a different signature in DBR versus OSS Spark; this removes compatibility issues caused by https://github.com/projectglow/glow/pull/151.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
