### PR TITLE
Fix staged release tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -302,6 +302,7 @@ lazy val stagedRelease = (project in file("core/src/test"))
     commonSettings,
     resourceDirectory in Test := baseDirectory.value / "resources",
     scalaSource in Test := baseDirectory.value / "scala",
+    unmanagedSourceDirectories in Test += baseDirectory.value / "shim" / "2.4",
     libraryDependencies ++= testSparkDependencies ++ testCoreDependencies :+
     "io.projectglow" %% "glow" % stableVersion.value % "test",
     resolvers := Seq("bintray-staging" at "https://dl.bintray.com/projectglow/glow"),


### PR DESCRIPTION
## What changes are proposed in this pull request?

With the changes made in https://github.com/projectglow/glow/pull/155, the staged release tests broke as its compilation does not pull in the appropriate Spark test shims. This PR adds the Spark 2.4 test shims to the Scala sources used to compile the tests.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

The staged 0.3.0 release tests pass (with the bumped stable version):
- stagedRelease_2_11/test
- stagedRelease_2_12/test