### PR TITLE
Allow 0 partitions in big VCF/BGEN writers and pipe transformer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Java targets
 target
+core/project
 core/src/test/target
 core/target
 project/target

--- a/core/src/main/scala/io/projectglow/bgen/BigBgenDatasource.scala
+++ b/core/src/main/scala/io/projectglow/bgen/BigBgenDatasource.scala
@@ -45,13 +45,10 @@ object BigBgenDatasource extends HlsEventRecorder {
   import io.projectglow.common.BgenOptions._
 
   private def parseOptions(options: Map[String, String]): BigBgenOptions = {
-    val bitsPerProb =
-      options.getOrElse(BITS_PER_PROB_KEY, BITS_PER_PROB_DEFAULT_VALUE).toInt
+    val bitsPerProb = options.getOrElse(BITS_PER_PROB_KEY, BITS_PER_PROB_DEFAULT_VALUE).toInt
     val maxPloidy = options.getOrElse(MAX_PLOIDY_KEY, MAX_PLOIDY_VALUE).toInt
-    val defaultPloidy =
-      options.getOrElse(DEFAULT_PLOIDY_KEY, DEFAULT_PLOIDY_VALUE).toInt
-    val defaultPhasing =
-      options.getOrElse(DEFAULT_PHASING_KEY, DEFAULT_PHASING_VALUE).toBoolean
+    val defaultPloidy = options.getOrElse(DEFAULT_PLOIDY_KEY, DEFAULT_PLOIDY_VALUE).toInt
+    val defaultPhasing = options.getOrElse(DEFAULT_PHASING_KEY, DEFAULT_PHASING_VALUE).toBoolean
     BigBgenOptions(bitsPerProb, maxPloidy, defaultPloidy, defaultPhasing)
   }
 

--- a/core/src/main/scala/io/projectglow/bgen/BigBgenDatasource.scala
+++ b/core/src/main/scala/io/projectglow/bgen/BigBgenDatasource.scala
@@ -22,7 +22,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SQLUtils}
 import org.apache.spark.sql.sources.DataSourceRegister
 
-import io.projectglow.common.GlowLogging
 import io.projectglow.common.logging.{HlsEventRecorder, HlsTagValues}
 import io.projectglow.sql.BigFileDatasource
 import io.projectglow.sql.util.ComDatabricksDataSource
@@ -41,7 +40,7 @@ class BigBgenDatasource extends BigFileDatasource with DataSourceRegister {
 
 class ComDatabricksBigBgenDatasource extends BigBgenDatasource with ComDatabricksDataSource
 
-object BigBgenDatasource extends HlsEventRecorder with GlowLogging {
+object BigBgenDatasource extends HlsEventRecorder {
 
   import io.projectglow.common.BgenOptions._
 

--- a/core/src/main/scala/io/projectglow/transformers/pipe/Piper.scala
+++ b/core/src/main/scala/io/projectglow/transformers/pipe/Piper.scala
@@ -92,8 +92,7 @@ private[projectglow] object Piper extends GlowLogging {
 
     if (schemaSeq.length != 1) {
       throw new IllegalStateException(
-        s"Cannot infer schema: saw ${schemaSeq.length} distinct schemas."
-      )
+        s"Cannot infer schema: saw ${schemaSeq.length} distinct schemas.")
     }
 
     val schema = schemaSeq.head
@@ -101,12 +100,7 @@ private[projectglow] object Piper extends GlowLogging {
       it.drop(1).asInstanceOf[Iterator[InternalRow]]
     }
 
-    SQLUtils.internalCreateDataFrame(
-      df.sparkSession,
-      internalRowRDD,
-      schema,
-      isStreaming = false
-    )
+    SQLUtils.internalCreateDataFrame(df.sparkSession, internalRowRDD, schema, isStreaming = false)
   }
 }
 
@@ -127,9 +121,7 @@ private[projectglow] class ProcessHelper(
     environment.foreach { case (k, v) => pbEnv.put(k, v) }
     process = pb.start()
 
-    val stdinWriterThread = new Thread(
-      s"${ProcessHelper.STDIN_WRITER_THREAD_PREFIX} for $cmd"
-    ) {
+    val stdinWriterThread = new Thread(s"${ProcessHelper.STDIN_WRITER_THREAD_PREFIX} for $cmd") {
       override def run(): Unit = {
         SQLUtils.setTaskContext(context)
         val out = process.getOutputStream
@@ -144,9 +136,7 @@ private[projectglow] class ProcessHelper(
     }
     stdinWriterThread.start()
 
-    val stderrReaderThread = new Thread(
-      s"${ProcessHelper.STDERR_READER_THREAD_PREFIX} for $cmd"
-    ) {
+    val stderrReaderThread = new Thread(s"${ProcessHelper.STDERR_READER_THREAD_PREFIX} for $cmd") {
       override def run(): Unit = {
         val err = process.getErrorStream
         try {
@@ -197,8 +187,7 @@ class PipeIterator(
     outputFormatter: OutputFormatter)
     extends Iterator[Any] {
 
-  private val processHelper =
-    new ProcessHelper(cmd, environment, writeInput, TaskContext.get)
+  private val processHelper = new ProcessHelper(cmd, environment, writeInput, TaskContext.get)
   private val inputStream = processHelper.startProcess()
   private val baseIterator = outputFormatter.makeIterator(inputStream)
 
@@ -215,9 +204,7 @@ class PipeIterator(
     } else {
       val exitStatus = processHelper.waitForProcess()
       if (exitStatus != 0) {
-        throw new IllegalStateException(
-          s"Subprocess exited with status $exitStatus"
-        )
+        throw new IllegalStateException(s"Subprocess exited with status $exitStatus")
       }
       false
     }

--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -26,7 +26,6 @@ import org.apache.spark.sql.{DataFrame, SQLUtils}
 import org.apache.spark.sql.sources.DataSourceRegister
 import org.seqdoop.hadoop_bam.util.DatabricksBGZFOutputStream
 
-import io.projectglow.common.GlowLogging
 import io.projectglow.common.logging.{HlsEventRecorder, HlsTagValues}
 import io.projectglow.sql.BigFileDatasource
 import io.projectglow.sql.util.{ComDatabricksDataSource, SerializableConfiguration}
@@ -44,7 +43,7 @@ class BigVCFDatasource extends BigFileDatasource with DataSourceRegister {
 
 class ComDatabricksBigVCFDatasource extends BigVCFDatasource with ComDatabricksDataSource
 
-object BigVCFDatasource extends HlsEventRecorder with GlowLogging {
+object BigVCFDatasource extends HlsEventRecorder {
 
   def serializeDataFrame(options: Map[String, String], data: DataFrame): RDD[Array[Byte]] = {
 

--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -60,9 +60,7 @@ object BigVCFDatasource extends HlsEventRecorder {
     }
     val nParts = inputRdd.getNumPartitions
 
-    val conf = VCFFileFormat.hadoopConfWithBGZ(
-      data.sparkSession.sparkContext.hadoopConfiguration
-    )
+    val conf = VCFFileFormat.hadoopConfWithBGZ(data.sparkSession.sparkContext.hadoopConfiguration)
     val serializableConf = new SerializableConfiguration(conf)
     val firstNonemptyPartition =
       inputRdd.mapPartitions(iter => Iterator(iter.nonEmpty)).collect.indexOf(true)
@@ -73,13 +71,11 @@ object BigVCFDatasource extends HlsEventRecorder {
       throw new SparkException("Cannot infer header for empty VCF.")
     }
 
-    val (headerLineSet, providedSampleIds) =
-      VCFHeaderUtils.parseHeaderLinesAndSamples(
-        options,
-        Some(VCFHeaderUtils.INFER_HEADER),
-        schema,
-        conf
-      )
+    val (headerLineSet, providedSampleIds) = VCFHeaderUtils.parseHeaderLinesAndSamples(
+      options,
+      Some(VCFHeaderUtils.INFER_HEADER),
+      schema,
+      conf)
     val sampleIdInfo = if (providedSampleIds.isInstanceOf[SampleIds]) {
       providedSampleIds
     } else {
@@ -92,20 +88,15 @@ object BigVCFDatasource extends HlsEventRecorder {
         val conf = serializableConf.value
         val codec = new CompressionCodecFactory(conf)
         val baos = new ByteArrayOutputStream()
-        val outputStream =
-          Option(codec.getCodec(new Path(BigFileDatasource.checkPath(options))))
-            .map(_.createOutputStream(baos))
-            .getOrElse(baos)
+        val outputStream = Option(codec.getCodec(new Path(BigFileDatasource.checkPath(options))))
+          .map(_.createOutputStream(baos))
+          .getOrElse(baos)
 
         // Write an empty GZIP block iff this is the last partition
-        DatabricksBGZFOutputStream.setWriteEmptyBlockOnClose(
-          outputStream,
-          idx == nParts - 1
-        )
+        DatabricksBGZFOutputStream.setWriteEmptyBlockOnClose(outputStream, idx == nParts - 1)
 
         // Write the header if this is the first nonempty partition
-        val partitionWithHeader =
-          if (firstNonemptyPartition == -1) 0 else firstNonemptyPartition
+        val partitionWithHeader = if (firstNonemptyPartition == -1) 0 else firstNonemptyPartition
 
         val writer =
           new VCFFileWriter(
@@ -115,8 +106,7 @@ object BigVCFDatasource extends HlsEventRecorder {
             schema,
             conf,
             outputStream,
-            idx == partitionWithHeader
-          )
+            idx == partitionWithHeader)
 
         it.foreach { row =>
           writer.write(row)

--- a/core/src/main/scala/org/apache/spark/sql/SQLUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SQLUtils.scala
@@ -79,4 +79,9 @@ object SQLUtils {
   def getSessionExtensions(session: SparkSession): SparkSessionExtensions = {
     session.extensions
   }
+
+  // Used to create an empty RDD with 1 partition to be compatible with our partition-based functionality
+  def createEmptyRDD(sess: SparkSession, numPartitions: Int = 1): RDD[InternalRow] = {
+    sess.sparkContext.parallelize(Seq.empty[InternalRow], numPartitions)
+  }
 }

--- a/core/src/test/scala/io/projectglow/bgen/BgenWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/bgen/BgenWriterSuite.scala
@@ -282,14 +282,20 @@ class BgenWriterSuite extends BgenConverterBaseTest {
 
     val newBgenFile = createTempBgen
 
-    spark
+    val inputDf = spark
       .sparkContext
       .emptyRDD[BgenRow]
       .toDS
       .repartition(1)
+
+    inputDf.explain(true)
+    assert(false)
+
+    inputDf
       .write
       .format(sourceName)
       .save(newBgenFile)
+
     val rewrittenDs = spark
       .read
       .format("bgen")

--- a/core/src/test/scala/io/projectglow/bgen/BgenWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/bgen/BgenWriterSuite.scala
@@ -40,19 +40,22 @@ class BgenWriterSuite extends BgenConverterBaseTest {
     val newBgenFile = createTempBgen
 
     val origDs =
-      spark.read
+      spark
+        .read
         .format("bgen")
         .schema(BgenRow.schema)
         .load(testBgen)
         .as[BgenRow]
-    origDs.write
+    origDs
+      .write
       .option("bitsPerProbability", bitsPerProb)
       .format(sourceName)
       .save(newBgenFile)
 
     // Check that rows in new file are approximately equal
     val newDs =
-      spark.read
+      spark
+        .read
         .format("bgen")
         .schema(BgenRow.schema)
         .load(newBgenFile)
@@ -81,15 +84,14 @@ class BgenWriterSuite extends BgenConverterBaseTest {
     )
   }
 
-  def changeVariantIdAndRsid(variantId: Option[String],
-                             rsid: Option[String],
-                             testBgen: String) {
+  def changeVariantIdAndRsid(variantId: Option[String], rsid: Option[String], testBgen: String) {
     val sess = spark
     import sess.implicits._
 
     val newBgenFile = createTempBgen
 
-    val origDs = spark.read
+    val origDs = spark
+      .read
       .format("bgen")
       .load(testBgen)
       .as[BgenRow]
@@ -97,11 +99,13 @@ class BgenWriterSuite extends BgenConverterBaseTest {
         br.copy(names = Seq(variantId, rsid).flatten)
       }
 
-    origDs.write
+    origDs
+      .write
       .format(sourceName)
       .save(newBgenFile)
 
-    spark.read
+    spark
+      .read
       .format("bgen")
       .load(newBgenFile)
       .as[BgenRow]
@@ -111,27 +115,31 @@ class BgenWriterSuite extends BgenConverterBaseTest {
       }
   }
 
-  def roundTripVcf(testBgen: String,
-                   testVcf: String,
-                   bitsPerProb: Int,
-                   defaultPhasing: Option[Boolean] = None) {
+  def roundTripVcf(
+      testBgen: String,
+      testVcf: String,
+      bitsPerProb: Int,
+      defaultPhasing: Option[Boolean] = None) {
 
     val sess = spark
     import sess.implicits._
 
     val newBgenFile = createTempBgen
 
-    val bgenDs = spark.read
+    val bgenDs = spark
+      .read
       .format("bgen")
       .schema(BgenRow.schema)
       .load(testBgen)
       .as[BgenRow]
-    val origVcfDs = spark.read
+    val origVcfDs = spark
+      .read
       .format("vcf")
       .option("includeSampleIds", true)
       .load(testVcf)
 
-    val writer = origVcfDs.write
+    val writer = origVcfDs
+      .write
       .option("bitsPerProbability", bitsPerProb)
       .format(sourceName)
 
@@ -142,7 +150,8 @@ class BgenWriterSuite extends BgenConverterBaseTest {
     }
     writerWithDefaultPhasing.save(newBgenFile)
 
-    val vcfDs = spark.read
+    val vcfDs = spark
+      .read
       .format("bgen")
       .schema(BgenRow.schema)
       .load(newBgenFile)
@@ -213,26 +222,26 @@ class BgenWriterSuite extends BgenConverterBaseTest {
       BgenRecordWriter
         .calculateIntProbabilities(bitsPerProb = 2, Seq(0.5, 0.5))
         .sorted ==
-        Seq(1, 2) // Unrounded: 1.5, 1.5
+      Seq(1, 2) // Unrounded: 1.5, 1.5
     )
     assert(
       BgenRecordWriter
         .calculateIntProbabilities(bitsPerProb = 8, Seq(0.99, 0.01)) ==
-        Seq(252, 3) // Unrounded: 252.45, 2.55
+      Seq(252, 3) // Unrounded: 252.45, 2.55
     )
     assert(
       BgenRecordWriter.calculateIntProbabilities(
         bitsPerProb = 16,
         Seq(0.605, 0.283, 0.122)
       ) ==
-        Seq(39649, 18547, 7995) // Unrounded: 39648.675, 18546.405, 7995.27
+      Seq(39649, 18547, 7995) // Unrounded: 39648.675, 18546.405, 7995.27
     )
     assert(
       BgenRecordWriter.calculateIntProbabilities(
         bitsPerProb = 32,
         Seq(0.23, 0.27, 0.16, 0.34)
       ) ==
-        Seq(987842478, 1159641170, 687194767, 1460288881)
+      Seq(987842478, 1159641170, 687194767, 1460288881)
       // Unrounded: 987842477.85, 1159641169.65, 687194767.2, 1460288880.3
     )
   }
@@ -256,7 +265,8 @@ class BgenWriterSuite extends BgenConverterBaseTest {
     import sess.implicits._
 
     val e = intercept[SparkException](
-      spark.sparkContext
+      spark
+        .sparkContext
         .emptyRDD[BgenRow]
         .toDS
         .write
@@ -272,14 +282,16 @@ class BgenWriterSuite extends BgenConverterBaseTest {
 
     val newBgenFile = createTempBgen
 
-    spark.sparkContext
+    spark
+      .sparkContext
       .emptyRDD[BgenRow]
       .toDS
       .repartition(1)
       .write
       .format(sourceName)
       .save(newBgenFile)
-    val rewrittenDs = spark.read
+    val rewrittenDs = spark
+      .read
       .format("bgen")
       .load(newBgenFile)
     assert(rewrittenDs.collect.isEmpty)
@@ -325,10 +337,13 @@ class BgenWriterSuite extends BgenConverterBaseTest {
     val newBgenFile = createTempBgen
 
     val noGtRow = BgenRow("chr1", 10, 11, Nil, "A", Seq("T"), Nil)
-    Seq(noGtRow).toDS.write
+    Seq(noGtRow)
+      .toDS
+      .write
       .format("bigbgen")
       .save(newBgenFile)
-    val rewrittenDs = spark.read
+    val rewrittenDs = spark
+      .read
       .format("bgen")
       .schema(BgenRow.schema)
       .load(newBgenFile)

--- a/core/src/test/scala/io/projectglow/bgen/BgenWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/bgen/BgenWriterSuite.scala
@@ -40,12 +40,7 @@ class BgenWriterSuite extends BgenConverterBaseTest {
     val newBgenFile = createTempBgen
 
     val origDs =
-      spark
-        .read
-        .format("bgen")
-        .schema(BgenRow.schema)
-        .load(testBgen)
-        .as[BgenRow]
+      spark.read.format("bgen").schema(BgenRow.schema).load(testBgen).as[BgenRow]
     origDs
       .write
       .option("bitsPerProbability", bitsPerProb)
@@ -54,19 +49,12 @@ class BgenWriterSuite extends BgenConverterBaseTest {
 
     // Check that rows in new file are approximately equal
     val newDs =
-      spark
-        .read
-        .format("bgen")
-        .schema(BgenRow.schema)
-        .load(newBgenFile)
-        .as[BgenRow]
+      spark.read.format("bgen").schema(BgenRow.schema).load(newBgenFile).as[BgenRow]
     origDs
       .sort("contigName", "start")
       .collect
       .zip(newDs.sort("contigName", "start").collect)
-      .foreach {
-        case (or, nr) => checkBgenRowsEqual(or, nr, true, bitsPerProb)
-      }
+      .foreach { case (or, nr) => checkBgenRowsEqual(or, nr, true, bitsPerProb) }
 
     // Check that size of files are approximately equal (excluding free data area in header)
     val origStream = new FileInputStream(testBgen)
@@ -196,11 +184,7 @@ class BgenWriterSuite extends BgenConverterBaseTest {
   }
 
   test("single name") {
-    changeVariantIdAndRsid(
-      Some("fakeId"),
-      None,
-      s"$testRoot/example.16bits.bgen"
-    )
+    changeVariantIdAndRsid(Some("fakeId"), None, s"$testRoot/example.16bits.bgen")
   }
 
   test("invalid bitsPerProb option") {
@@ -219,28 +203,19 @@ class BgenWriterSuite extends BgenConverterBaseTest {
 
   test("Represent probabilities as int") {
     assert(
-      BgenRecordWriter
-        .calculateIntProbabilities(bitsPerProb = 2, Seq(0.5, 0.5))
-        .sorted ==
+      BgenRecordWriter.calculateIntProbabilities(bitsPerProb = 2, Seq(0.5, 0.5)).sorted ==
       Seq(1, 2) // Unrounded: 1.5, 1.5
     )
     assert(
-      BgenRecordWriter
-        .calculateIntProbabilities(bitsPerProb = 8, Seq(0.99, 0.01)) ==
+      BgenRecordWriter.calculateIntProbabilities(bitsPerProb = 8, Seq(0.99, 0.01)) ==
       Seq(252, 3) // Unrounded: 252.45, 2.55
     )
     assert(
-      BgenRecordWriter.calculateIntProbabilities(
-        bitsPerProb = 16,
-        Seq(0.605, 0.283, 0.122)
-      ) ==
+      BgenRecordWriter.calculateIntProbabilities(bitsPerProb = 16, Seq(0.605, 0.283, 0.122)) ==
       Seq(39649, 18547, 7995) // Unrounded: 39648.675, 18546.405, 7995.27
     )
     assert(
-      BgenRecordWriter.calculateIntProbabilities(
-        bitsPerProb = 32,
-        Seq(0.23, 0.27, 0.16, 0.34)
-      ) ==
+      BgenRecordWriter.calculateIntProbabilities(bitsPerProb = 32, Seq(0.23, 0.27, 0.16, 0.34)) ==
       Seq(987842478, 1159641170, 687194767, 1460288881)
       // Unrounded: 987842477.85, 1159641169.65, 687194767.2, 1460288880.3
     )
@@ -260,7 +235,7 @@ class BgenWriterSuite extends BgenConverterBaseTest {
     )
   }
 
-  test("Empty file with determined header") {
+  test("Empty file") {
     val sess = spark
     import sess.implicits._
 
@@ -282,36 +257,19 @@ class BgenWriterSuite extends BgenConverterBaseTest {
   }
 
   test("unphased 8 bit VCF") {
-    roundTripVcf(
-      s"$testRoot/example.8bits.bgen",
-      s"$testRoot/example.8bits.vcf",
-      8
-    )
+    roundTripVcf(s"$testRoot/example.8bits.bgen", s"$testRoot/example.8bits.vcf", 8)
   }
 
   test("unphased 16 bit (with missing samples) VCF") {
-    roundTripVcf(
-      s"$testRoot/example.16bits.bgen",
-      s"$testRoot/example.16bits.vcf",
-      16
-    )
+    roundTripVcf(s"$testRoot/example.16bits.bgen", s"$testRoot/example.16bits.vcf", 16)
   }
 
   test("unphased 32 bit VCF") {
-    roundTripVcf(
-      s"$testRoot/example.32bits.bgen",
-      s"$testRoot/example.32bits.vcf",
-      32
-    )
+    roundTripVcf(s"$testRoot/example.32bits.bgen", s"$testRoot/example.32bits.vcf", 32)
   }
 
   test("phased VCF") {
-    roundTripVcf(
-      s"$testRoot/phased.16bits.bgen",
-      s"$testRoot/phased.16bits.vcf",
-      16,
-      Some(true)
-    )
+    roundTripVcf(s"$testRoot/phased.16bits.bgen", s"$testRoot/phased.16bits.vcf", 16, Some(true))
   }
 
   test("No genotype") {

--- a/core/src/test/scala/io/projectglow/bgen/BgenWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/bgen/BgenWriterSuite.scala
@@ -260,38 +260,16 @@ class BgenWriterSuite extends BgenConverterBaseTest {
     )
   }
 
-  test("0 partitions exception check") {
-    val sess = spark
-    import sess.implicits._
-
-    val e = intercept[SparkException](
-      spark
-        .sparkContext
-        .emptyRDD[BgenRow]
-        .toDS
-        .write
-        .format(sourceName)
-        .save(createTempBgen)
-    )
-    assert(e.getMessage.contains("the DataFrame has zero partitions"))
-  }
-
   test("Empty file with determined header") {
     val sess = spark
     import sess.implicits._
 
     val newBgenFile = createTempBgen
 
-    val inputDf = spark
+    spark
       .sparkContext
       .emptyRDD[BgenRow]
       .toDS
-      .repartition(1)
-
-    inputDf.explain(true)
-    assert(false)
-
-    inputDf
       .write
       .format(sourceName)
       .save(newBgenFile)

--- a/core/src/test/scala/io/projectglow/transformers/pipe/CSVPiperSuite.scala
+++ b/core/src/test/scala/io/projectglow/transformers/pipe/CSVPiperSuite.scala
@@ -16,7 +16,6 @@
 
 package io.projectglow.transformers.pipe
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.{StringType, StructField}
 
@@ -142,21 +141,6 @@ class CSVPiperSuite extends GlowBaseTest {
     assert(outputDf.collect.toSeq == inputDf.collect.toSeq)
   }
 
-  test("0 partitions exception check") {
-    val e = intercept[SparkException] {
-      pipeCsv(
-        spark.emptyDataFrame,
-        s"""["cat", "-"]""",
-        Some(" "),
-        Some(" "),
-        Some(true),
-        Some(true)
-      )
-    }
-
-    assert(e.getMessage.contains("the DataFrame has zero partitions"))
-  }
-
   test("No rows with header") {
     val inputDf =
       spark
@@ -165,8 +149,6 @@ class CSVPiperSuite extends GlowBaseTest {
         .option("header", "true")
         .csv(saige)
         .limit(0)
-        .repartition(1)
-    inputDf.explain(true)
 
     val outputDf =
       pipeCsv(

--- a/core/src/test/scala/io/projectglow/transformers/pipe/CSVPiperSuite.scala
+++ b/core/src/test/scala/io/projectglow/transformers/pipe/CSVPiperSuite.scala
@@ -68,39 +68,21 @@ class CSVPiperSuite extends GlowBaseTest {
     Glow.transform(
       "pipe",
       inputDf,
-      baseOptions ++ inputDelimiterOption ++ outputDelimiterOption ++ inputHeaderOption ++ outputHeaderOption
-    )
+      baseOptions ++ inputDelimiterOption ++ outputDelimiterOption ++ inputHeaderOption ++ outputHeaderOption)
   }
 
   test("Delimiter and header") {
-    val inputDf =
-      spark.read.option("delimiter", " ").option("header", "true").csv(saige)
+    val inputDf = spark.read.option("delimiter", " ").option("header", "true").csv(saige)
     val outputDf =
-      pipeCsv(
-        inputDf,
-        """["sed", "s/:/ /g"]""",
-        Some(":"),
-        Some(" "),
-        Some(true),
-        Some(true)
-      )
+      pipeCsv(inputDf, """["sed", "s/:/ /g"]""", Some(":"), Some(" "), Some(true), Some(true))
     assert(outputDf.schema == inputDf.schema)
     assert(
-      outputDf.orderBy("CHR", "POS").collect.toSeq == inputDf
-        .orderBy("CHR", "POS")
-        .collect
-        .toSeq
-    )
+      outputDf.orderBy("CHR", "POS").collect.toSeq == inputDf.orderBy("CHR", "POS").collect.toSeq)
   }
 
   test("Some empty partitions with header") {
     val inputDf =
-      spark
-        .read
-        .option("delimiter", " ")
-        .option("header", "true")
-        .csv(saige)
-        .repartition(20)
+      spark.read.option("delimiter", " ").option("header", "true").csv(saige).repartition(20)
     val outputDf =
       pipeCsv(
         inputDf,
@@ -112,30 +94,14 @@ class CSVPiperSuite extends GlowBaseTest {
       )
     assert(outputDf.schema == inputDf.schema)
     assert(
-      outputDf.orderBy("CHR", "POS").collect.toSeq == inputDf
-        .orderBy("CHR", "POS")
-        .collect
-        .toSeq
-    )
+      outputDf.orderBy("CHR", "POS").collect.toSeq == inputDf.orderBy("CHR", "POS").collect.toSeq)
   }
 
   test("Single row with header") {
     val inputDf =
-      spark
-        .read
-        .option("delimiter", " ")
-        .option("header", "true")
-        .csv(saige)
-        .limit(1)
+      spark.read.option("delimiter", " ").option("header", "true").csv(saige).limit(1)
     val outputDf =
-      pipeCsv(
-        inputDf,
-        s"""["cat", "-"]""",
-        Some(" "),
-        Some(" "),
-        Some(true),
-        Some(true)
-      )
+      pipeCsv(inputDf, s"""["cat", "-"]""", Some(" "), Some(" "), Some(true), Some(true))
 
     assert(outputDf.schema == inputDf.schema)
     assert(outputDf.collect.toSeq == inputDf.collect.toSeq)
@@ -143,67 +109,34 @@ class CSVPiperSuite extends GlowBaseTest {
 
   test("No rows with header") {
     val inputDf =
-      spark
-        .read
-        .option("delimiter", " ")
-        .option("header", "true")
-        .csv(saige)
-        .limit(0)
+      spark.read.option("delimiter", " ").option("header", "true").csv(saige).limit(0)
 
     val outputDf =
-      pipeCsv(
-        inputDf,
-        s"""["cat", "-"]""",
-        Some(" "),
-        Some(" "),
-        Some(true),
-        Some(true)
-      )
+      pipeCsv(inputDf, s"""["cat", "-"]""", Some(" "), Some(" "), Some(true), Some(true))
     assert(outputDf.schema == inputDf.schema)
     assert(outputDf.isEmpty)
   }
 
   test("Default options: comma delimiter and no header") {
-    val inputDf =
-      spark.read.option("delimiter", ",").option("header", "false").csv(csv)
+    val inputDf = spark.read.option("delimiter", ",").option("header", "false").csv(csv)
     val outputDf = pipeCsv(inputDf, s"""["cat", "-"]""", None, None, None, None)
 
     assert(outputDf.schema == inputDf.schema)
-    assert(
-      outputDf.orderBy("_c0").collect.toSeq == inputDf
-        .orderBy("_c0")
-        .collect
-        .toSeq
-    )
+    assert(outputDf.orderBy("_c0").collect.toSeq == inputDf.orderBy("_c0").collect.toSeq)
   }
 
   test("Some empty partitions without header") {
     val inputDf =
-      spark
-        .read
-        .option("delimiter", ",")
-        .option("header", "false")
-        .csv(csv)
-        .repartition(20)
+      spark.read.option("delimiter", ",").option("header", "false").csv(csv).repartition(20)
     val outputDf = pipeCsv(inputDf, s"""["cat", "-"]""", None, None, None, None)
 
     assert(outputDf.schema == inputDf.schema)
-    assert(
-      outputDf.orderBy("_c0").collect.toSeq == inputDf
-        .orderBy("_c0")
-        .collect
-        .toSeq
-    )
+    assert(outputDf.orderBy("_c0").collect.toSeq == inputDf.orderBy("_c0").collect.toSeq)
   }
 
   test("Single row and no header") {
     val inputDf =
-      spark
-        .read
-        .option("delimiter", ",")
-        .option("header", "false")
-        .csv(csv)
-        .limit(1)
+      spark.read.option("delimiter", ",").option("header", "false").csv(csv).limit(1)
     val outputDf = pipeCsv(inputDf, s"""["cat", "-"]""", None, None, None, None)
 
     assert(outputDf.schema == inputDf.schema)
@@ -212,15 +145,9 @@ class CSVPiperSuite extends GlowBaseTest {
 
   test("No rows and no header") {
     val inputDf =
-      spark
-        .read
-        .option("delimiter", ",")
-        .option("header", "false")
-        .csv(csv)
-        .limit(0)
+      spark.read.option("delimiter", ",").option("header", "false").csv(csv).limit(0)
     assertThrows[IllegalStateException](
-      pipeCsv(inputDf, s"""["cat", "-"]""", None, None, None, None)
-    )
+      pipeCsv(inputDf, s"""["cat", "-"]""", None, None, None, None))
   }
 
   test("GWAS") {
@@ -240,9 +167,7 @@ class CSVPiperSuite extends GlowBaseTest {
       outputDf.schema.fields.toSeq == Seq(
         StructField("CHR", StringType, nullable = true),
         StructField("POS", StringType, nullable = true),
-        StructField("pValue", StringType, nullable = true)
-      )
-    )
+        StructField("pValue", StringType, nullable = true)))
     assert(outputDf.count == input.count)
     assert(outputDf.filter("pValue = 0.5").count == outputDf.count)
   }
@@ -271,17 +196,11 @@ class CSVPiperSuite extends GlowBaseTest {
   }
 
   test("Big file") {
-    val inputDf =
-      spark.read.text(s"$testDataHome/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf")
+    val inputDf = spark.read.text(s"$testDataHome/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf")
     val outputDf = Glow.transform(
       "pipe",
       inputDf,
-      Map(
-        "inputFormatter" -> "text",
-        "outputFormatter" -> "csv",
-        "cmd" -> """["cat", "-"]"""
-      )
-    )
+      Map("inputFormatter" -> "text", "outputFormatter" -> "csv", "cmd" -> """["cat", "-"]"""))
     assert(outputDf.count() == 1103)
   }
 }

--- a/core/src/test/scala/io/projectglow/transformers/pipe/CSVPiperSuite.scala
+++ b/core/src/test/scala/io/projectglow/transformers/pipe/CSVPiperSuite.scala
@@ -166,6 +166,8 @@ class CSVPiperSuite extends GlowBaseTest {
         .csv(saige)
         .limit(0)
         .repartition(1)
+    inputDf.explain(true)
+
     val outputDf =
       pipeCsv(
         inputDf,

--- a/core/src/test/scala/io/projectglow/transformers/pipe/CSVPiperSuite.scala
+++ b/core/src/test/scala/io/projectglow/transformers/pipe/CSVPiperSuite.scala
@@ -16,6 +16,7 @@
 
 package io.projectglow.transformers.pipe
 
+import org.apache.spark.SparkException
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.{StringType, StructField}
 
@@ -68,67 +69,157 @@ class CSVPiperSuite extends GlowBaseTest {
     Glow.transform(
       "pipe",
       inputDf,
-      baseOptions ++ inputDelimiterOption ++ outputDelimiterOption ++ inputHeaderOption ++ outputHeaderOption)
+      baseOptions ++ inputDelimiterOption ++ outputDelimiterOption ++ inputHeaderOption ++ outputHeaderOption
+    )
   }
 
   test("Delimiter and header") {
-    val inputDf = spark.read.option("delimiter", " ").option("header", "true").csv(saige)
+    val inputDf =
+      spark.read.option("delimiter", " ").option("header", "true").csv(saige)
     val outputDf =
-      pipeCsv(inputDf, """["sed", "s/:/ /g"]""", Some(":"), Some(" "), Some(true), Some(true))
+      pipeCsv(
+        inputDf,
+        """["sed", "s/:/ /g"]""",
+        Some(":"),
+        Some(" "),
+        Some(true),
+        Some(true)
+      )
     assert(outputDf.schema == inputDf.schema)
     assert(
-      outputDf.orderBy("CHR", "POS").collect.toSeq == inputDf.orderBy("CHR", "POS").collect.toSeq)
+      outputDf.orderBy("CHR", "POS").collect.toSeq == inputDf
+        .orderBy("CHR", "POS")
+        .collect
+        .toSeq
+    )
   }
 
   test("Some empty partitions with header") {
     val inputDf =
-      spark.read.option("delimiter", " ").option("header", "true").csv(saige).repartition(20)
+      spark
+        .read
+        .option("delimiter", " ")
+        .option("header", "true")
+        .csv(saige)
+        .repartition(20)
     val outputDf =
-      pipeCsv(inputDf, s"""["cat", "-"]""", Some(" "), Some(" "), Some(true), Some(true))
+      pipeCsv(
+        inputDf,
+        s"""["cat", "-"]""",
+        Some(" "),
+        Some(" "),
+        Some(true),
+        Some(true)
+      )
     assert(outputDf.schema == inputDf.schema)
     assert(
-      outputDf.orderBy("CHR", "POS").collect.toSeq == inputDf.orderBy("CHR", "POS").collect.toSeq)
+      outputDf.orderBy("CHR", "POS").collect.toSeq == inputDf
+        .orderBy("CHR", "POS")
+        .collect
+        .toSeq
+    )
   }
 
   test("Single row with header") {
     val inputDf =
-      spark.read.option("delimiter", " ").option("header", "true").csv(saige).limit(1)
+      spark
+        .read
+        .option("delimiter", " ")
+        .option("header", "true")
+        .csv(saige)
+        .limit(1)
     val outputDf =
-      pipeCsv(inputDf, s"""["cat", "-"]""", Some(" "), Some(" "), Some(true), Some(true))
+      pipeCsv(
+        inputDf,
+        s"""["cat", "-"]""",
+        Some(" "),
+        Some(" "),
+        Some(true),
+        Some(true)
+      )
 
     assert(outputDf.schema == inputDf.schema)
     assert(outputDf.collect.toSeq == inputDf.collect.toSeq)
   }
 
+  test("0 partitions exception check") {
+    val e = intercept[SparkException] {
+      pipeCsv(
+        spark.emptyDataFrame,
+        s"""["cat", "-"]""",
+        Some(" "),
+        Some(" "),
+        Some(true),
+        Some(true)
+      )
+    }
+
+    assert(e.getMessage.contains("the DataFrame has zero partitions"))
+  }
+
   test("No rows with header") {
     val inputDf =
-      spark.read.option("delimiter", " ").option("header", "true").csv(saige).limit(0)
+      spark
+        .read
+        .option("delimiter", " ")
+        .option("header", "true")
+        .csv(saige)
+        .limit(0)
+        .repartition(1)
     val outputDf =
-      pipeCsv(inputDf, s"""["cat", "-"]""", Some(" "), Some(" "), Some(true), Some(true))
+      pipeCsv(
+        inputDf,
+        s"""["cat", "-"]""",
+        Some(" "),
+        Some(" "),
+        Some(true),
+        Some(true)
+      )
     assert(outputDf.schema == inputDf.schema)
     assert(outputDf.isEmpty)
   }
 
   test("Default options: comma delimiter and no header") {
-    val inputDf = spark.read.option("delimiter", ",").option("header", "false").csv(csv)
+    val inputDf =
+      spark.read.option("delimiter", ",").option("header", "false").csv(csv)
     val outputDf = pipeCsv(inputDf, s"""["cat", "-"]""", None, None, None, None)
 
     assert(outputDf.schema == inputDf.schema)
-    assert(outputDf.orderBy("_c0").collect.toSeq == inputDf.orderBy("_c0").collect.toSeq)
+    assert(
+      outputDf.orderBy("_c0").collect.toSeq == inputDf
+        .orderBy("_c0")
+        .collect
+        .toSeq
+    )
   }
 
   test("Some empty partitions without header") {
     val inputDf =
-      spark.read.option("delimiter", ",").option("header", "false").csv(csv).repartition(20)
+      spark
+        .read
+        .option("delimiter", ",")
+        .option("header", "false")
+        .csv(csv)
+        .repartition(20)
     val outputDf = pipeCsv(inputDf, s"""["cat", "-"]""", None, None, None, None)
 
     assert(outputDf.schema == inputDf.schema)
-    assert(outputDf.orderBy("_c0").collect.toSeq == inputDf.orderBy("_c0").collect.toSeq)
+    assert(
+      outputDf.orderBy("_c0").collect.toSeq == inputDf
+        .orderBy("_c0")
+        .collect
+        .toSeq
+    )
   }
 
   test("Single row and no header") {
     val inputDf =
-      spark.read.option("delimiter", ",").option("header", "false").csv(csv).limit(1)
+      spark
+        .read
+        .option("delimiter", ",")
+        .option("header", "false")
+        .csv(csv)
+        .limit(1)
     val outputDf = pipeCsv(inputDf, s"""["cat", "-"]""", None, None, None, None)
 
     assert(outputDf.schema == inputDf.schema)
@@ -137,9 +228,15 @@ class CSVPiperSuite extends GlowBaseTest {
 
   test("No rows and no header") {
     val inputDf =
-      spark.read.option("delimiter", ",").option("header", "false").csv(csv).limit(0)
+      spark
+        .read
+        .option("delimiter", ",")
+        .option("header", "false")
+        .csv(csv)
+        .limit(0)
     assertThrows[IllegalStateException](
-      pipeCsv(inputDf, s"""["cat", "-"]""", None, None, None, None))
+      pipeCsv(inputDf, s"""["cat", "-"]""", None, None, None, None)
+    )
   }
 
   test("GWAS") {
@@ -159,7 +256,9 @@ class CSVPiperSuite extends GlowBaseTest {
       outputDf.schema.fields.toSeq == Seq(
         StructField("CHR", StringType, nullable = true),
         StructField("POS", StringType, nullable = true),
-        StructField("pValue", StringType, nullable = true)))
+        StructField("pValue", StringType, nullable = true)
+      )
+    )
     assert(outputDf.count == input.count)
     assert(outputDf.filter("pValue = 0.5").count == outputDf.count)
   }
@@ -180,17 +279,25 @@ class CSVPiperSuite extends GlowBaseTest {
     assert(
       outputDf.schema.fields.toSeq == Seq(
         StructField("Gene", StringType, nullable = true),
-        StructField("pValue", StringType, nullable = true)))
+        StructField("pValue", StringType, nullable = true)
+      )
+    )
     assert(outputDf.count == 2)
     assert(outputDf.filter("pValue = 0.5").count == outputDf.count)
   }
 
   test("Big file") {
-    val inputDf = spark.read.text(s"$testDataHome/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf")
+    val inputDf =
+      spark.read.text(s"$testDataHome/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf")
     val outputDf = Glow.transform(
       "pipe",
       inputDf,
-      Map("inputFormatter" -> "text", "outputFormatter" -> "csv", "cmd" -> """["cat", "-"]"""))
+      Map(
+        "inputFormatter" -> "text",
+        "outputFormatter" -> "csv",
+        "cmd" -> """["cat", "-"]"""
+      )
+    )
     assert(outputDf.count() == 1103)
   }
 }

--- a/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFFileWriterSuite.scala
@@ -631,7 +631,6 @@ class SingleFileVCFWriterSuite extends VCFFileWriterSuite("bigvcf") {
       .sparkContext
       .emptyRDD[VCFRow]
       .toDS
-      .repartition(1)
       .write
       .option("vcfHeader", NA12878)
       .format(sourceName)
@@ -642,24 +641,6 @@ class SingleFileVCFWriterSuite extends VCFFileWriterSuite("bigvcf") {
 
     assert(truthHeader.getMetaDataInInputOrder.equals(writtenHeader.getMetaDataInInputOrder))
     assert(truthHeader.getGenotypeSamples == writtenHeader.getGenotypeSamples)
-  }
-
-  test("Bigvcf 0 partitions exception check") {
-    val sess = spark
-    import sess.implicits._
-
-    val tempFile = createTempVcf.toString
-
-    assertThrows[SparkException](
-      spark
-        .sparkContext
-        .emptyRDD[VCFRow]
-        .toDS
-        .write
-        .option("vcfHeader", NA12878)
-        .format(sourceName)
-        .save(tempFile)
-    )
   }
 
   def sliceInferredSampleIds(

--- a/core/src/test/scala/io/projectglow/vcf/VCFPiperSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFPiperSuite.scala
@@ -45,13 +45,19 @@ class VCFPiperSuite extends GlowBaseTest {
           .getAllStackTraces
           .asScala
           .keySet
-          .exists(_.getName.startsWith(ProcessHelper.STDIN_WRITER_THREAD_PREFIX)))
+          .exists(
+            _.getName.startsWith(ProcessHelper.STDIN_WRITER_THREAD_PREFIX)
+          )
+      )
       assert(
         !Thread
           .getAllStackTraces
           .asScala
           .keySet
-          .exists(_.getName.startsWith(ProcessHelper.STDERR_READER_THREAD_PREFIX)))
+          .exists(
+            _.getName.startsWith(ProcessHelper.STDERR_READER_THREAD_PREFIX)
+          )
+      )
     }
 
     super.afterEach()
@@ -71,7 +77,8 @@ class VCFPiperSuite extends GlowBaseTest {
       "inputFormatter" -> "vcf",
       "outputFormatter" -> "vcf",
       "inVcfHeader" -> "infer",
-      "cmd" -> s"""["$script"]""")
+      "cmd" -> s"""["$script"]"""
+    )
     val outputDf = Glow.transform("pipe", inputDf, options)
 
     (inputDf, outputDf)
@@ -85,17 +92,18 @@ class VCFPiperSuite extends GlowBaseTest {
   }
 
   test("Prepend chr") {
-    val (_, df) = pipeScript(
-      na12878,
-      s"$testDataHome/vcf/scripts/prepend-chr.sh"
-    )
+    val (_, df) =
+      pipeScript(na12878, s"$testDataHome/vcf/scripts/prepend-chr.sh")
     df.cache()
 
     import sess.implicits._
 
     // Prepends chr
-    val distinctContigNames = df.select("contigName").as[String].distinct.collect
-    assert(distinctContigNames.length == 1 && distinctContigNames.head == "chr21")
+    val distinctContigNames =
+      df.select("contigName").as[String].distinct.collect
+    assert(
+      distinctContigNames.length == 1 && distinctContigNames.head == "chr21"
+    )
 
     // Include sample names
     val sampleSeq = df.select("genotypes.sampleId").as[Seq[String]].head
@@ -109,25 +117,22 @@ class VCFPiperSuite extends GlowBaseTest {
   }
 
   test("Remove INFO") {
-    val (_, df) = pipeScript(
-      na12878,
-      s"$testDataHome/vcf/scripts/remove-info.sh"
-    )
+    val (_, df) =
+      pipeScript(na12878, s"$testDataHome/vcf/scripts/remove-info.sh")
 
     assert(!df.schema.fieldNames.exists(_.startsWith("INFO_")))
   }
 
   test("Remove non-header rows") {
-    val (inputDf, outputDf) = pipeScript(
-      na12878,
-      s"$testDataHome/vcf/scripts/remove-rows.sh"
-    )
+    val (inputDf, outputDf) =
+      pipeScript(na12878, s"$testDataHome/vcf/scripts/remove-rows.sh")
 
     assert(inputDf.schema == outputDf.schema)
     assert(outputDf.isEmpty)
   }
 
-  private val baseTextOptions = Map("inputFormatter" -> "vcf", "outputFormatter" -> "text")
+  private val baseTextOptions =
+    Map("inputFormatter" -> "vcf", "outputFormatter" -> "text")
   test("environment variables") {
     import sess.implicits._
 
@@ -137,7 +142,8 @@ class VCFPiperSuite extends GlowBaseTest {
         "env_animal" -> "monkey",
         "env_a" -> "b",
         "env_c" -> "D",
-        "envE" -> "F")
+        "envE" -> "F"
+      )
     val df = readVcf(na12878)
     val output = Glow
       .transform("pipe", df, options)
@@ -154,7 +160,10 @@ class VCFPiperSuite extends GlowBaseTest {
     val df = readVcf(na12878).repartition(8)
     assert(df.count == 4)
 
-    val options = baseTextOptions ++ Map("cmd" -> """["wc", "-l"]""", "in_vcfHeader" -> na12878)
+    val options = baseTextOptions ++ Map(
+        "cmd" -> """["wc", "-l"]""",
+        "in_vcfHeader" -> na12878
+      )
     val output = Glow.transform("pipe", df, options)
     assert(output.count() == 8)
   }
@@ -163,7 +172,10 @@ class VCFPiperSuite extends GlowBaseTest {
     val df = readVcf(na12878).repartition(8)
     assert(df.count == 4)
 
-    val options = baseTextOptions ++ Map("cmd" -> """["wc", "-l"]""", "in_vcfHeader" -> "infer")
+    val options = baseTextOptions ++ Map(
+        "cmd" -> """["wc", "-l"]""",
+        "in_vcfHeader" -> "infer"
+      )
     assertThrows[SparkException](Glow.transform("pipe", df, options))
   }
 
@@ -178,13 +190,28 @@ class VCFPiperSuite extends GlowBaseTest {
     assert(ex.getMessage.contains("No such file or directory"))
   }
 
-  test("header only") {
-    val df = readVcf(na12878).limit(0)
+  test("0 partitions exception check") {
     val options = Map(
       "inputFormatter" -> "vcf",
       "outputFormatter" -> "text",
       "in_vcfHeader" -> na12878,
-      "cmd" -> s"""["cat", "-"]""")
+      "cmd" -> s"""["cat", "-"]"""
+    )
+    val e = intercept[SparkException] {
+      Glow.transform("pipe", spark.emptyDataFrame, options)
+    }
+
+    assert(e.getMessage.contains("the DataFrame has zero partitions"))
+  }
+
+  test("header only") {
+    val df = readVcf(na12878).limit(0).repartition(1)
+    val options = Map(
+      "inputFormatter" -> "vcf",
+      "outputFormatter" -> "text",
+      "in_vcfHeader" -> na12878,
+      "cmd" -> s"""["cat", "-"]"""
+    )
     val output = Glow.transform("pipe", df, options)
     assert(output.count == 28)
   }
@@ -208,7 +235,8 @@ class VCFPiperSuite extends GlowBaseTest {
       "inputFormatter" -> "vcf",
       "outputFormatter" -> "vcf",
       "in_vcfHeader" -> na12878,
-      "cmd" -> s"""["cat", "-"]""")
+      "cmd" -> s"""["cat", "-"]"""
+    )
     val output = Glow.transform("pipe", df, options)
     assert(output.count() == 4)
   }
@@ -227,19 +255,27 @@ class VCFPiperSuite extends GlowBaseTest {
       "inputFormatter" -> "vcf",
       "outputFormatter" -> "vcf",
       "in_vcfHeader" -> "infer",
-      "cmd" -> s"""["cat", "-"]""")
+      "cmd" -> s"""["cat", "-"]"""
+    )
     val outputDf = Glow.transform("pipe", inputDf.toDF, options)
 
-    inputDf.as[SimpleVcfRow].collect.zip(outputDf.as[SimpleVcfRow].collect).foreach {
-      case (vc1, vc2) =>
-        var missingSampleIdx = 0
-        val gtsWithSampleIds = vc1.genotypes.map { gt =>
-          missingSampleIdx += 1
-          gt.copy(sampleId = Some(s"sample_$missingSampleIdx"))
-        }
-        val vc1WithSampleIds = vc1.copy(genotypes = gtsWithSampleIds)
-        assert(vc1WithSampleIds.equals(vc2), s"VC1 $vc1WithSampleIds VC2 $vc2")
-    }
+    inputDf
+      .as[SimpleVcfRow]
+      .collect
+      .zip(outputDf.as[SimpleVcfRow].collect)
+      .foreach {
+        case (vc1, vc2) =>
+          var missingSampleIdx = 0
+          val gtsWithSampleIds = vc1.genotypes.map { gt =>
+            missingSampleIdx += 1
+            gt.copy(sampleId = Some(s"sample_$missingSampleIdx"))
+          }
+          val vc1WithSampleIds = vc1.copy(genotypes = gtsWithSampleIds)
+          assert(
+            vc1WithSampleIds.equals(vc2),
+            s"VC1 $vc1WithSampleIds VC2 $vc2"
+          )
+      }
   }
 
   test("input validation stringency") {
@@ -256,11 +292,14 @@ class VCFPiperSuite extends GlowBaseTest {
       "inValidationStringency" -> "STRICT",
       "cmd" -> s"""["cat", "-"]"""
     )
-    assertThrows[IllegalArgumentException](Glow.transform("pipe", inputDf, options))
+    assertThrows[IllegalArgumentException](
+      Glow.transform("pipe", inputDf, options)
+    )
   }
 
   test("output validation stringency") {
-    val row = Seq("1", "1", "id", "C", "T,GT", "1", ".", "AC=monkey").mkString("\t")
+    val row =
+      Seq("1", "1", "id", "C", "T,GT", "1", ".", "AC=monkey").mkString("\t")
 
     val file = Files.createTempFile("test-vcf", ".vcf")
     val header =
@@ -303,7 +342,11 @@ class VCFPiperSuite extends GlowBaseTest {
 
     val e = intercept[SparkException](Glow.transform("pipe", inputDf, options))
     assert(e.getCause.isInstanceOf[IllegalArgumentException])
-    assert(e.getCause.getMessage.contains("Could not build variant context: Contig cannot be null"))
+    assert(
+      e.getCause
+        .getMessage
+        .contains("Could not build variant context: Contig cannot be null")
+    )
   }
 }
 

--- a/core/src/test/scala/io/projectglow/vcf/VCFPiperSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFPiperSuite.scala
@@ -190,22 +190,8 @@ class VCFPiperSuite extends GlowBaseTest {
     assert(ex.getMessage.contains("No such file or directory"))
   }
 
-  test("0 partitions exception check") {
-    val options = Map(
-      "inputFormatter" -> "vcf",
-      "outputFormatter" -> "text",
-      "in_vcfHeader" -> na12878,
-      "cmd" -> s"""["cat", "-"]"""
-    )
-    val e = intercept[SparkException] {
-      Glow.transform("pipe", spark.emptyDataFrame, options)
-    }
-
-    assert(e.getMessage.contains("the DataFrame has zero partitions"))
-  }
-
   test("header only") {
-    val df = readVcf(na12878).limit(0).repartition(1)
+    val df = readVcf(na12878).limit(0)
     val options = Map(
       "inputFormatter" -> "vcf",
       "outputFormatter" -> "text",


### PR DESCRIPTION
## What changes are proposed in this pull request?

We currently have inconsistent behavior between the following tools that act on RDD partitions in the case that there are 0 partitions:
- Big BGEN writer
- Big VCF writer
- Pipe transformer

Now, we replace the underlying 0-row, 0-partition RDD with a 0-row, 1-partition RDD. This allows users to write big VCF/BGENs or pipe with the header alone. This will un-break our tests on [SPARK-30780](https://issues.apache.org/jira/browse/SPARK-30780), which causes empty DataFrames to (usually) be backed by an empty RDD with 0 partitions.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests