### PR TITLE
Part 2: Prepare for Spark 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,8 @@ lazy val commonSettings = Seq(
       // Be permissive for other files
       MergeStrategy.first
   },
-  scalacOptions += "-target:jvm-1.8"
+  scalacOptions += "-target:jvm-1.8",
+  resolvers += "Apache Snapshots" at "https://repository.apache.org/snapshots/"
 )
 
 lazy val functionsYml = settingKey[File]("functionsYml")

--- a/core/src/main/scala/io/projectglow/SparkShimBase.scala
+++ b/core/src/main/scala/io/projectglow/SparkShimBase.scala
@@ -16,12 +16,15 @@
 
 package io.projectglow
 
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 
 // Spark APIs that are not inter-version compatible
 trait SparkShimBase {
   type CSVOptions
   type UnivocityParser
+
+  def wrapUnivocityParse(parser: UnivocityParser)(input: String): Option[InternalRow]
 
   def createExpressionInfo(
       className: String,

--- a/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityGenerator.scala
+++ b/core/src/main/scala/org/apache/spark/sql/execution/datasources/csv/UnivocityGenerator.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.catalyst.util._
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
 
-import io.projectglow.SparkShim.{CSVOptions => ShimCSVOptions, UnivocityParser => ShimUnivocityParser}
+import io.projectglow.SparkShim.{CSVOptions => ShimCSVOptions, UnivocityParser => ShimUnivocityParser, wrapUnivocityParse}
 
 /**
  * Inlined version of [[UnivocityGenerator]] to handle compatibility between Spark distributions.
@@ -108,7 +108,7 @@ object UnivocityParserUtils {
       parser: ShimUnivocityParser,
       schema: StructType): Iterator[InternalRow] = {
     val safeParser = new MinimalFailureSafeParser[String](
-      input => Seq(parser.parse(input)),
+      input => wrapUnivocityParse(parser)(input).toSeq,
       parser.options.parseMode,
       schema,
       parser.options.columnNameOfCorruptRecord

--- a/core/src/main/shim/2.4/SparkShim.scala
+++ b/core/src/main/shim/2.4/SparkShim.scala
@@ -16,12 +16,17 @@
 
 package io.projectglow
 
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 
 // Spark 2.4 APIs that are not inter-version compatible
 object SparkShim extends SparkShimBase {
   override type CSVOptions = org.apache.spark.sql.execution.datasources.csv.CSVOptions
   override type UnivocityParser = org.apache.spark.sql.execution.datasources.csv.UnivocityParser
+
+  override def wrapUnivocityParse(parser: UnivocityParser)(input: String): Option[InternalRow] = {
+    Some(parser.parse(input))
+  }
 
   override def createExpressionInfo(
       className: String,

--- a/core/src/main/shim/3.0/SparkShim.scala
+++ b/core/src/main/shim/3.0/SparkShim.scala
@@ -16,6 +16,7 @@
 
 package io.projectglow
 
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.ExpressionInfo
 
 // Spark 3.0 APIs that are not inter-version compatible
@@ -24,6 +25,10 @@ object SparkShim extends SparkShimBase {
   // Refactors classes from [[org.apache.spark.sql.execution.datasources.csv]] to [[org.apache.spark.sql.catalyst.csv]]
   override type CSVOptions = org.apache.spark.sql.catalyst.csv.CSVOptions
   override type UnivocityParser = org.apache.spark.sql.catalyst.csv.UnivocityParser
+
+  override def wrapUnivocityParse(parser: UnivocityParser)(input: String): Option[InternalRow] = {
+    parser.parse(input)
+  }
 
   // [SPARK-27328][SQL] Add 'deprecated' in ExpressionDescription for extended usage and SQL doc
   // Adds 'deprecated' argument to the ExpressionInfo constructor


### PR DESCRIPTION
## What changes are proposed in this pull request?

Spark 3 APIs have changed since `preview-2`. To make sure we stay up-to-date with the most recent version of Spark 3, I've added a resolver for the nightly snapshot builds so we can test against it.

The latest version of Spark 3 has a different API for its univocity parser, resulting in the creation of a new shim.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

Ran tests on the Spark 3 nightly snapshot.
