### PR TITLE
Convert UTF8Strings to Strings before storing in VariantContext

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/InternalRowToVariantContextConverter.scala
+++ b/core/src/main/scala/io/projectglow/vcf/InternalRowToVariantContextConverter.scala
@@ -511,11 +511,23 @@ class InternalRowToVariantContextConverter(
 
   private def parseField(field: StructField, row: InternalRow, offset: Int): AnyRef = {
     val value = field.dataType match {
+      case StringType =>
+        row.getString(offset)
+      case ArrayType(StringType, _) =>
+        val arrayData = row.getArray(offset)
+        val arr = new Array[String](arrayData.numElements())
+        var i = 0
+        while (i < arr.length) {
+          arr(i) = arrayData.getUTF8String(i).toString
+          i += 1
+        }
+        arr
       case dt: ArrayType =>
         new JArrayList(JArrays.asList(row.getArray(offset).toObjectArray(dt.elementType): _*))
       case dt =>
         row.get(offset, dt)
     }
+
     value match {
       case null => VCFConstants.MISSING_VALUE_v4
       case "" => VCFConstants.MISSING_VALUE_v4

--- a/core/src/main/scala/io/projectglow/vcf/InternalRowToVariantContextConverter.scala
+++ b/core/src/main/scala/io/projectglow/vcf/InternalRowToVariantContextConverter.scala
@@ -515,10 +515,10 @@ class InternalRowToVariantContextConverter(
         row.getString(offset)
       case ArrayType(StringType, _) =>
         val arrayData = row.getArray(offset)
-        val arr = new Array[String](arrayData.numElements())
+        val arr = new JArrayList[String](arrayData.numElements())
         var i = 0
-        while (i < arr.length) {
-          arr(i) = arrayData.getUTF8String(i).toString
+        while (i < arrayData.numElements()) {
+          arr.add(arrayData.getUTF8String(i).toString)
           i += 1
         }
         arr

--- a/core/src/test/scala/io/projectglow/vcf/InternalRowToVariantContextConverterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/InternalRowToVariantContextConverterSuite.scala
@@ -123,6 +123,6 @@ class InternalRowToVariantContextConverterSuite extends GlowBaseTest {
     assert(genotype.getExtendedAttribute("string") == "monkey")
     assert(
       genotype.getExtendedAttribute("string_array").asInstanceOf[JList[String]].asScala
-        == Seq("monkey"))
+      == Seq("monkey"))
   }
 }

--- a/core/src/test/scala/io/projectglow/vcf/InternalRowToVariantContextConverterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/InternalRowToVariantContextConverterSuite.scala
@@ -99,11 +99,11 @@ class InternalRowToVariantContextConverterSuite extends GlowBaseTest {
       .withColumn("end", lit(2))
       .withColumn("referenceAllele", lit("A"))
       .withColumn("alternateAlleles", lit(array(lit("G"))))
-      .withColumn("INFO_string", lit("monkey"))
-      .withColumn("INFO_string_array", array(lit("monkey")))
+      .withColumn("INFO_string", lit("monkey1"))
+      .withColumn("INFO_string_array", array(lit("monkey2")))
       .withColumn(
         "genotypes",
-        array(struct(lit("monkey").as("string"), array(lit("monkey")).as("string_array"))))
+        array(struct(lit("monkey3").as("string"), array(lit("monkey4")).as("string_array"))))
     val schema = df.schema
     val vc = df
       .queryExecution
@@ -117,12 +117,12 @@ class InternalRowToVariantContextConverterSuite extends GlowBaseTest {
         it.flatMap(converter.convert)
       }
       .first()
-    assert(vc.getAttribute("string") == "monkey")
-    assert(vc.getAttribute("string_array").asInstanceOf[JList[String]].asScala == Seq("monkey"))
+    assert(vc.getAttribute("string") == "monkey1")
+    assert(vc.getAttribute("string_array").asInstanceOf[JList[String]].asScala == Seq("monkey2"))
     val genotype = vc.getGenotype(0)
-    assert(genotype.getExtendedAttribute("string") == "monkey")
+    assert(genotype.getExtendedAttribute("string") == "monkey3")
     assert(
       genotype.getExtendedAttribute("string_array").asInstanceOf[JList[String]].asScala
-      == Seq("monkey"))
+      == Seq("monkey4"))
   }
 }

--- a/core/src/test/scala/io/projectglow/vcf/InternalRowToVariantContextConverterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/InternalRowToVariantContextConverterSuite.scala
@@ -16,6 +16,8 @@
 
 package io.projectglow.vcf
 
+import java.util.{List => JList}
+
 import scala.collection.JavaConverters._
 import htsjdk.samtools.ValidationStringency
 import org.apache.spark.sql.types.{ArrayType, DataType, MapType, StringType, StructField, StructType}
@@ -86,5 +88,41 @@ class InternalRowToVariantContextConverterSuite extends GlowBaseTest {
       InternalRowToVariantContextConverter.getGenotypeSchema(schema)
     }
     assert(e.getMessage.contains("`genotypes` column must be an array of structs"))
+  }
+
+  test("convert string fields") {
+    import org.apache.spark.sql.functions._
+    val df = spark
+      .range(1)
+      .withColumn("contigName", lit("1"))
+      .withColumn("start", lit(1))
+      .withColumn("end", lit(2))
+      .withColumn("referenceAllele", lit("A"))
+      .withColumn("alternateAlleles", lit(array(lit("G"))))
+      .withColumn("INFO_string", lit("monkey"))
+      .withColumn("INFO_string_array", array(lit("monkey")))
+      .withColumn(
+        "genotypes",
+        array(struct(lit("monkey").as("string"), array(lit("monkey")).as("string_array"))))
+    val schema = df.schema
+    val vc = df
+      .queryExecution
+      .toRdd
+      .mapPartitions { it =>
+        val header = VCFSchemaInferrer.headerLinesFromSchema(schema)
+        val converter = new InternalRowToVariantContextConverter(
+          schema,
+          header.toSet,
+          ValidationStringency.STRICT)
+        it.flatMap(converter.convert)
+      }
+      .first()
+    assert(vc.getAttribute("string") == "monkey")
+    assert(vc.getAttribute("string_array").asInstanceOf[JList[String]].asScala == Seq("monkey"))
+    val genotype = vc.getGenotype(0)
+    assert(genotype.getExtendedAttribute("string") == "monkey")
+    assert(
+      genotype.getExtendedAttribute("string_array").asInstanceOf[JList[String]].asScala
+        == Seq("monkey"))
   }
 }


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
Previously, we (I believe inadvertently) stored stringly typed info and format fields as Spark's `UTF8String`s when converting `InternalRow`s to `VariantContext`s. This could lead to the value changing over time if the Spark overwrites the buffer underlying the `UTF8String`. Instead, we should convert to plain ole `String`s when making VCs.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

I verified that a problematic job is fixed by this patch.
