### PR TITLE
Wrap VCF writer closing with try-catch

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/VCFStreamWriter.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFStreamWriter.scala
@@ -25,6 +25,8 @@ import htsjdk.variant.variantcontext.writer.{Options, VariantContextWriter, Vari
 import htsjdk.variant.variantcontext.{Genotype, GenotypeBuilder, VariantContext, VariantContextBuilder}
 import htsjdk.variant.vcf.{VCFHeader, VCFHeaderLine}
 
+import io.projectglow.common.GlowLogging
+
 /**
  * This internal row -> variant context stream writer maintains a header that is set exactly once. The sample IDs are
  * set by [[sampleIdInfo]] if predetermined, or inferred from the first written row otherwise.
@@ -45,6 +47,7 @@ class VCFStreamWriter(
     sampleIdInfo: SampleIdInfo,
     writeHeader: Boolean)
     extends Closeable
+    with GlowLogging
     with Serializable {
 
   var header: VCFHeader = _
@@ -148,6 +151,12 @@ class VCFStreamWriter(
       header = new VCFHeader(headerLineSet.asJava, sampleIds.asJava)
       writer.writeHeader(header)
     }
-    writer.close()
+
+    try {
+      writer.close()
+    } catch {
+      case e: Throwable =>
+        logger.warn("Could not close writer: " + e.getMessage)
+    }
   }
 }

--- a/core/src/test/scala/io/projectglow/vcf/VCFStreamWriterSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFStreamWriterSuite.scala
@@ -16,7 +16,8 @@
 
 package io.projectglow.vcf
 
-import java.io.{ByteArrayOutputStream, StringReader}
+import java.io.{BufferedOutputStream, ByteArrayOutputStream, FileOutputStream, StringReader}
+import java.nio.file.Files
 
 import scala.collection.JavaConverters._
 
@@ -117,5 +118,13 @@ class VCFStreamWriterSuite extends GlowBaseTest {
       writer.close()
     }
     assert(e.getMessage.contains("Cannot infer header for empty partition"))
+  }
+
+  test("Stream closes before writer closes") {
+    val tempFile = Files.createTempFile("test-file", ".tmp").toString
+    val stream = new BufferedOutputStream(new FileOutputStream(tempFile))
+    val writer = new VCFStreamWriter(stream, headerLines, SampleIds(actualSampleIds), true)
+    stream.close()
+    writer.close() // should not throw an exception
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

If the VCF input formatter's stream closes prematurely, it can break the writer when it closes. This wraps the writer's closing with a try-catch.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
