### PR TITLE
Make SingleFileWriter public

### DIFF
--- a/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
+++ b/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
@@ -89,7 +89,7 @@ trait BigFileUploader {
   def upload(bytes: RDD[Array[Byte]], path: String): Unit
 }
 
-private[projectglow] object SingleFileWriter extends GlowLogging {
+object SingleFileWriter extends GlowLogging {
 
   lazy val uploaders: Seq[BigFileUploader] = ServiceLoader
     .load(classOf[BigFileUploader])


### PR DESCRIPTION
## What changes are proposed in this pull request?

To avoid using visibility shims elsewhere, we should make the `SingleFileWriter` interface public.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
