### PR TITLE
Replace rdocumentation links

### DIFF
--- a/docs/source/tertiary/regression-tests.rst
+++ b/docs/source/tertiary/regression-tests.rst
@@ -87,7 +87,7 @@ Return
 ------
 
 The function returns a struct with the following fields. The computation of each value matches the
-`lm R package <https://www.rdocumentation.org/packages/stats/versions/3.6.1/topics/lm>`_.
+`lm R package <https://stat.ethz.ch/R-manual/R-patched/library/stats/html/lm.html>`_.
 
 .. list-table::
   :header-rows: 1
@@ -182,7 +182,7 @@ Return
 ------
 
 The function returns a struct with the following fields. The computation of each value matches the
-`glm R package <https://www.rdocumentation.org/packages/stats/versions/3.6.1/topics/glm>`_ for the
+`glm R package <https://stat.ethz.ch/R-manual/R-patched/library/stats/html/glm.html>`_ for the
 likelihood ratio test and the
 `logistf R package <https://cran.r-project.org/web/packages/logistf/logistf.pdf>`_ for the Firth
 test.


### PR DESCRIPTION
## What changes are proposed in this pull request?

The certs for rdocumentation.org are wrong, resulting in our link checker being broken
`SSLError(SSLCertVerificationError("hostname 'www.rdocumentation.org' doesn't match either of 'new.datacamp.com', '*.new.datacamp.com', 'datacamp.com', '*.datacamp.com'"))`

This PR replaces instances of rdocumentation.org with stat.ethz.ch/R-manual/.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
