### PR TITLE
Do not pipe empty RDD partitions

### DIFF
--- a/core/src/main/scala/io/projectglow/transformers/pipe/CSVOutputFormatter.scala
+++ b/core/src/main/scala/io/projectglow/transformers/pipe/CSVOutputFormatter.scala
@@ -51,7 +51,7 @@ class CSVOutputFormatter(parsedOptions: CSVOptions) extends OutputFormatter {
     val lines = IOUtils.lineIterator(stream, "UTF-8").asScala
     val filteredLines = CSVUtils.filterCommentAndEmpty(lines, parsedOptions)
 
-    if (!filteredLines.hasNext) {
+    if (filteredLines.isEmpty) {
       return Iterator.empty
     }
 

--- a/core/src/main/scala/io/projectglow/transformers/pipe/Piper.scala
+++ b/core/src/main/scala/io/projectglow/transformers/pipe/Piper.scala
@@ -75,7 +75,11 @@ private[projectglow] object Piper extends GlowLogging {
     // Each partition consists of an iterator with the schema, followed by [[InternalRow]]s with the
     // schema
     val schemaInternalRowRDD = inputRdd.mapPartitions { it =>
-      new PipeIterator(cmd, env, it, informatter, outputformatter)
+      if (it.isEmpty) {
+        Iterator.empty
+      } else {
+        new PipeIterator(cmd, env, it, informatter, outputformatter)
+      }
     }.persist(StorageLevel.DISK_ONLY)
 
     cachedRdds.synchronized {

--- a/core/src/test/scala/io/projectglow/transformers/pipe/CSVPiperSuite.scala
+++ b/core/src/test/scala/io/projectglow/transformers/pipe/CSVPiperSuite.scala
@@ -107,12 +107,21 @@ class CSVPiperSuite extends GlowBaseTest {
     assert(outputDf.collect.toSeq == inputDf.collect.toSeq)
   }
 
-  test("No rows") {
+  test("No rows input") {
     val inputDf =
       spark.read.option("delimiter", " ").option("header", "true").csv(saige).limit(0)
 
     val ex = intercept[IllegalStateException] {
       pipeCsv(inputDf, s"""["cat", "-"]""", Some(" "), Some(" "), Some(true), Some(true))
+    }
+    assert(ex.getMessage.contains("Cannot infer schema: saw 0 distinct schemas"))
+  }
+
+  test("No rows output") {
+    val inputDf = spark.read.option("delimiter", ",").option("header", "false").csv(csv)
+
+    val ex = intercept[IllegalStateException] {
+      pipeCsv(inputDf, s"""["echo"]""", Some(" "), Some(" "), None, None)
     }
     assert(ex.getMessage.contains("Cannot infer schema: saw 0 distinct schemas"))
   }

--- a/core/src/test/scala/io/projectglow/transformers/pipe/CSVPiperSuite.scala
+++ b/core/src/test/scala/io/projectglow/transformers/pipe/CSVPiperSuite.scala
@@ -107,14 +107,14 @@ class CSVPiperSuite extends GlowBaseTest {
     assert(outputDf.collect.toSeq == inputDf.collect.toSeq)
   }
 
-  test("No rows with header") {
+  test("No rows") {
     val inputDf =
       spark.read.option("delimiter", " ").option("header", "true").csv(saige).limit(0)
 
-    val outputDf =
+    val ex = intercept[IllegalStateException] {
       pipeCsv(inputDf, s"""["cat", "-"]""", Some(" "), Some(" "), Some(true), Some(true))
-    assert(outputDf.schema == inputDf.schema)
-    assert(outputDf.isEmpty)
+    }
+    assert(ex.getMessage.contains("Cannot infer schema: saw 0 distinct schemas"))
   }
 
   test("Default options: comma delimiter and no header") {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Rather than forcing users to repartition/coalesce when using the VCF input formatter, it makes sense to not invoke the piped command for any empty RDD partitions.

This change assumes that any piped tool has no output if it has no data in the input, even if there are metadata (ie. VCF or CSV header).

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

Modified tests for the VCF and CSV pipers.
