### PR TITLE
Ignore tabix index files when reading VCFs

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/TabixIndexHelper.scala
+++ b/core/src/main/scala/io/projectglow/vcf/TabixIndexHelper.scala
@@ -436,6 +436,11 @@ object TabixIndexHelper extends GlowLogging {
       // for what filteredSimpleInterval is
   ): Option[(Long, Long)] = {
 
+    // Do not read index files
+    if (file.filePath.endsWith(VCFFileFormat.INDEX_SUFFIX)) {
+      return None
+    }
+
     val path = new Path(file.filePath)
     val indexFile = new Path(file.filePath + VCFFileFormat.INDEX_SUFFIX)
     val isGzip = VCFFileFormat.isGzip(file, conf)

--- a/core/src/main/scala/io/projectglow/vcf/VCFHeaderUtils.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFHeaderUtils.scala
@@ -92,9 +92,13 @@ object VCFHeaderUtils extends GlowLogging {
     spark
       .sparkContext
       .parallelize(files)
-      .map { path =>
-        val (header, _) = VCFFileFormat.createVCFCodec(path, serializableConf.value)
-        header
+      .flatMap { path =>
+        if (path.endsWith(VCFFileFormat.INDEX_SUFFIX)) {
+          None
+        } else {
+          val (header, _) = VCFFileFormat.createVCFCodec(path, serializableConf.value)
+          Some(header)
+        }
       }
   }
 

--- a/core/src/test/scala/io/projectglow/vcf/TabixHelperSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/TabixHelperSuite.scala
@@ -823,4 +823,16 @@ class TabixHelperSuite extends GlowBaseTest with GlowLogging {
     )
   }
 
+  test("Do not try to read index files") {
+    val tbi = testBigVcf + ".tbi"
+    val path = new Path(tbi)
+    val conf = sparkContext.hadoopConfiguration
+    val fs = path.getFileSystem(conf)
+    val partitionedFile = PartitionedFile(InternalRow.empty, tbi, 0, 2)
+    val interval = Some(new SimpleInterval("0", 1, 2))
+    assert(
+      TabixIndexHelper
+        .getFileRangeToRead(fs, partitionedFile, conf, false, false, interval)
+        .isEmpty)
+  }
 }

--- a/core/src/test/scala/io/projectglow/vcf/VCFDatasourceSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFDatasourceSuite.scala
@@ -674,6 +674,17 @@ class VCFDatasourceSuite extends GlowBaseTest {
         null
       ))
   }
+
+  test("Do not break when reading index file") {
+    spark
+      .read
+      .format(sourceName)
+      .load(s"$testDataHome/tabix-test-vcf/NA12878_21_10002403.vcf.gz.tbi")
+  }
+
+  test("Do not break when reading directory with index files") {
+    spark.read.format(sourceName).load(s"$testDataHome/tabix-test-vcf")
+  }
 }
 
 // For testing only: schema based on CEUTrio VCF header

--- a/core/src/test/scala/io/projectglow/vcf/VCFHeaderUtilsSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFHeaderUtilsSuite.scala
@@ -228,4 +228,13 @@ class VCFHeaderUtilsSuite extends GlowBaseTest {
     val paths = writeVCFHeaders(Seq(file1, file2))
     VCFHeaderUtils.readHeaderLines(spark, paths) // no exception
   }
+
+  test("does not try to read tabix indices") {
+    assert(
+      VCFHeaderUtils
+        .readHeaderLines(
+          spark,
+          Seq(s"$testDataHome/tabix-test-vcf/NA12878_21_10002403NoTbi.vcf.gz.tbi"))
+        .isEmpty)
+  }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Users can use wildcards to directly read VCF files today, such as:
```
spark.read.format("vcf").load("vcf-dir/*.vcf.gz")
```

However, the VCF reader breaks if the user attempts to read directly from a directory containing tabix indices, such as:
```
spark.read.format("vcf").load("vcf-dir")
```

This PR tells the VCF reader to ignore tabix index files.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
