### PR TITLE
Address link check failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,4 +185,5 @@ workflows:
               only:
                 - master
     jobs:
+      - check-links
       - spark-3-tests

--- a/docs/source/tertiary/regression-tests.rst
+++ b/docs/source/tertiary/regression-tests.rst
@@ -87,7 +87,7 @@ Return
 ------
 
 The function returns a struct with the following fields. The computation of each value matches the
-`lm R package <https://stat.ethz.ch/R-manual/R-patched/library/stats/html/lm.html>`_.
+`lm R package <https://www.rdocumentation.org/packages/stats/versions/3.6.1/topics/lm>`_.
 
 .. list-table::
   :header-rows: 1
@@ -182,7 +182,7 @@ Return
 ------
 
 The function returns a struct with the following fields. The computation of each value matches the
-`glm R package <https://stat.ethz.ch/R-manual/R-patched/library/stats/html/glm.html>`_ for the
+`glm R package <https://www.rdocumentation.org/packages/stats/versions/3.6.1/topics/glm>`_ for the
 likelihood ratio test and the
 `logistf R package <https://cran.r-project.org/web/packages/logistf/logistf.pdf>`_ for the Firth
 test.


### PR DESCRIPTION
## What changes are proposed in this pull request?

The stat.ethz.ch R manual is returning 403s and rdocumentation.org's cert issue was resolved, so I'm reverting https://github.com/projectglow/glow/pull/178. I also added the link checker to the nightly tests so we can resolve broken links ASAP and avoid spurious failures on PRs.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
