### PR TITLE
Do not read contig and filter header lines on VCF ingest

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -480,7 +480,7 @@ private[vcf] object SchemaDelegate {
     val infoHeaderLines = ArrayBuffer[VCFInfoHeaderLine]()
     val formatHeaderLines = ArrayBuffer[VCFFormatHeaderLine]()
     VCFHeaderUtils
-      .readHeaderLines(spark, files.map(_.getPath.toString))
+      .readHeaderLines(spark, files.map(_.getPath.toString), getNonSchemaHeaderLines = false)
       .foreach {
         case i: VCFInfoHeaderLine => infoHeaderLines += i
         case f: VCFFormatHeaderLine => formatHeaderLines += f

--- a/core/src/test/scala/io/projectglow/vcf/VCFDatasourceSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFDatasourceSuite.scala
@@ -685,6 +685,17 @@ class VCFDatasourceSuite extends GlowBaseTest {
   test("Do not break when reading directory with index files") {
     spark.read.format(sourceName).load(s"$testDataHome/tabix-test-vcf")
   }
+
+  test("Do not break when reading VCFs with contig lines missing length") {
+    // Read two copies of the same file to trigger a header line merge
+    // May break if we parse contig header lines missing length
+    spark
+      .read
+      .format(sourceName)
+      .load(
+        s"$testDataHome/vcf/missing_contig_length.vcf",
+        s"$testDataHome/vcf/missing_contig_length.vcf")
+  }
 }
 
 // For testing only: schema based on CEUTrio VCF header

--- a/core/src/test/scala/io/projectglow/vcf/VCFHeaderUtilsSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFHeaderUtilsSuite.scala
@@ -135,7 +135,7 @@ class VCFHeaderUtilsSuite extends GlowBaseTest {
     }
   }
 
-  test("merge header lines") {
+  gridTest("merge all header lines")(Seq(true, false)) { getNonSchemaHeaderLines =>
     val file1 =
       s"""
          |##fileformat=VCFv4.2
@@ -155,28 +155,35 @@ class VCFHeaderUtilsSuite extends GlowBaseTest {
          |##contig=<ID=21,length=48129895>
        """.stripMargin
     val paths = writeVCFHeaders(Seq(file1, file2))
-    val lines = VCFHeaderUtils.readHeaderLines(spark, paths)
+    val lines = VCFHeaderUtils.readHeaderLines(spark, paths, getNonSchemaHeaderLines)
 
-    val expectedLines = Set(
+    val expectedSchemaLines = Set(
       new VCFInfoHeaderLine("animal", 1, VCFHeaderLineType.String, "monkey"),
       new VCFInfoHeaderLine("color", VCFHeaderLineCount.G, VCFHeaderLineType.String, ""),
       new VCFFormatHeaderLine("AD", VCFHeaderLineCount.R, VCFHeaderLineType.Integer, ""),
-      new VCFFormatHeaderLine("DP", 1, VCFHeaderLineType.Integer, ""),
-      new VCFFilterHeaderLine("LowQual", "Low Quality"),
-      new VCFContigHeaderLine("<ID=20,length=63025520>", VCFHeaderVersion.VCF4_2, "contig", 0),
-      new VCFContigHeaderLine("<ID=21,length=48129895>", VCFHeaderVersion.VCF4_2, "contig", 1)
+      new VCFFormatHeaderLine("DP", 1, VCFHeaderLineType.Integer, "")
     )
+    val expectedNonSchemaLines = if (getNonSchemaHeaderLines) {
+      Set(
+        new VCFFilterHeaderLine("LowQual", "Low Quality"),
+        new VCFContigHeaderLine("<ID=20,length=63025520>", VCFHeaderVersion.VCF4_2, "contig", 0),
+        new VCFContigHeaderLine("<ID=21,length=48129895>", VCFHeaderVersion.VCF4_2, "contig", 1)
+      )
+    } else {
+      Set.empty
+    }
 
     // We compare the string-encoded versions of the header lines to avoid direct object comparisons
     val sortedLines = lines.map(_.toString).toSet
-    val sortedExpectedLines = expectedLines.map(_.toString)
+    val sortedExpectedLines = (expectedSchemaLines ++ expectedNonSchemaLines).map(_.toString)
     assert(lines.size == sortedLines.size)
     assert(sortedLines == sortedExpectedLines)
   }
 
   def checkLinesIncompatible(file1: String, file2: String): Unit = {
     val paths = writeVCFHeaders(Seq(file1, file2))
-    val ex = intercept[SparkException](VCFHeaderUtils.readHeaderLines(spark, paths))
+    val ex = intercept[SparkException](
+      VCFHeaderUtils.readHeaderLines(spark, paths, getNonSchemaHeaderLines = true))
     assert(ex.getCause.isInstanceOf[IllegalArgumentException])
   }
 
@@ -226,7 +233,7 @@ class VCFHeaderUtilsSuite extends GlowBaseTest {
          |##FORMAT=<ID=animal,Number=2,Type=String,Description="monkey">
        """.stripMargin
     val paths = writeVCFHeaders(Seq(file1, file2))
-    VCFHeaderUtils.readHeaderLines(spark, paths) // no exception
+    VCFHeaderUtils.readHeaderLines(spark, paths, getNonSchemaHeaderLines = true) // no exception
   }
 
   test("does not try to read tabix indices") {
@@ -234,7 +241,8 @@ class VCFHeaderUtilsSuite extends GlowBaseTest {
       VCFHeaderUtils
         .readHeaderLines(
           spark,
-          Seq(s"$testDataHome/tabix-test-vcf/NA12878_21_10002403NoTbi.vcf.gz.tbi"))
+          Seq(s"$testDataHome/tabix-test-vcf/NA12878_21_10002403NoTbi.vcf.gz.tbi"),
+          getNonSchemaHeaderLines = true)
         .isEmpty)
   }
 }

--- a/test-data/vcf/missing_contig_length.vcf
+++ b/test-data/vcf/missing_contig_length.vcf
@@ -1,0 +1,7 @@
+##fileformat=VCFv4.2
+##FORMAT=<ID=AD,Number=1,Type=Integer,Description="Allelic depths for the ref and alt alleles in theorder listed">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth; some reads may have beenfiltered">
+##contig=<ID=1>
+##contig=<ID=2>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	SAMPLE1
+1	1	a	A	G	.	.	.	AD	1,2


### PR DESCRIPTION
## What changes are proposed in this pull request?

With https://github.com/projectglow/glow/pull/173, VCF ingest now fails when merging files with contig lines that are missing the `length` field. This is resolved in newer versions of the HTSJDK as of https://github.com/samtools/htsjdk/pull/1418.

As we don't need contig and filter header lines for schema inference during VCF ingest, we can skip reading them entirely. This PR adds an option to skip reading non-schema header lines while reading unique header lines.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
