### PR TITLE
Save conda cache before installing pyspark3 dev build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,10 @@ jobs:
           keys:
             - conda-deps-v1-{{ checksum "python/environment.yml" }}
       - *install_conda_deps
+      - save_cache:
+          paths:
+            - /home/circleci/conda
+          key: conda-deps-v1-{{ checksum "python/environment.yml" }}
       - run:
           name: Check docs links
           environment:
@@ -65,10 +69,6 @@ jobs:
             export PATH=$HOME/conda/envs/glow/bin:$PATH
             cd docs
             make linkcheck
-      - save_cache:
-          paths:
-            - /home/circleci/conda
-          key: conda-deps-v1-{{ checksum "python/environment.yml" }}
 
   scala-2_11-tests:
     <<: *setup_base
@@ -78,6 +78,10 @@ jobs:
           keys:
             - conda-deps-v1-{{ checksum "python/environment.yml" }}
       - *install_conda_deps
+      - save_cache:
+          paths:
+            - /home/circleci/conda
+          key: conda-deps-v1-{{ checksum "python/environment.yml" }}
       - run:
           name: Run Scala tests
           environment:
@@ -104,10 +108,6 @@ jobs:
           path: ~/glow/core/target/scala-2.11/test-reports
       - codecov/upload:
           file: "core/target/scala-2.11/scoverage-report/scoverage.xml"
-      - save_cache:
-          paths:
-            - /home/circleci/conda
-          key: conda-deps-v1-{{ checksum "python/environment.yml" }}
 
   scala-2_12-tests:
     <<: *setup_base
@@ -117,6 +117,10 @@ jobs:
           keys:
             - conda-deps-v1-{{ checksum "python/environment.yml" }}
       - *install_conda_deps
+      - save_cache:
+          paths:
+            - /home/circleci/conda
+          key: conda-deps-v1-{{ checksum "python/environment.yml" }}
       - run:
           name: Run Scala tests
           environment:
@@ -141,10 +145,6 @@ jobs:
           destination: unit-tests.log
       - store_test_results:
           path: ~/glow/core/target/scala-2.12/test-reports
-      - save_cache:
-          paths:
-            - /home/circleci/conda
-          key: conda-deps-v1-{{ checksum "python/environment.yml" }}
 
   spark-3-tests:
     <<: *setup_base
@@ -152,13 +152,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - spark3-conda-deps-v1-{{ checksum "python/environment.yml" }}
+            - conda-deps-v1-{{ checksum "python/environment.yml" }}
       - *install_conda_deps
-      # Save cache before installing pyspark3 so that we pick up new updates
       - save_cache:
           paths:
             - /home/circleci/conda
-          key: spark3-conda-deps-v1-{{ checksum "python/environment.yml" }}
+          key: conda-deps-v1-{{ checksum "python/environment.yml" }}
       - *install_pyspark3
       - run:
           name: Run Scala tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,6 +154,11 @@ jobs:
           keys:
             - spark3-conda-deps-v1-{{ checksum "python/environment.yml" }}
       - *install_conda_deps
+      # Save cache before installing pyspark3 so that we pick up new updates
+      - save_cache:
+          paths:
+            - /home/circleci/conda
+          key: spark3-conda-deps-v1-{{ checksum "python/environment.yml" }}
       - *install_pyspark3
       - run:
           name: Run Scala tests
@@ -176,10 +181,6 @@ jobs:
             export PATH=$HOME/conda/envs/glow/bin:$PATH
             export SPARK_VERSION="3.0.1-SNAPSHOT"
             sbt docs_2_12/test exit
-      - save_cache:
-          paths:
-            - /home/circleci/conda
-          key: spark3-conda-deps-v1-{{ checksum "python/environment.yml" }}
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ core-test-names.log
 unit-tests.log
 
 # Test artifacts
-Miniconda3-latest-Linux-x86_64.sh
+Miniconda3*.sh

--- a/python/environment.yml
+++ b/python/environment.yml
@@ -3,6 +3,7 @@ channels:
   - bioconda
 dependencies:
   - python=3.7
+  - bedtools
   - jinja2
   - numpy=1.17.4
   - nomkl # Skip MKL for local development
@@ -12,7 +13,6 @@ dependencies:
   - pyspark=2.4.5
   - pytest
   - pyyaml
-  - bedtools
   - sphinx
   - sphinx_rtd_theme
   - pip:


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?

Previously uninstalling pyspark from the environment would fail because it was absent from the cache. We'll also get new pyspark updates this way, although the package we install may be immutable.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
