### PR TITLE
Fix mean substitution lambda variable usage

### DIFF
--- a/core/src/main/scala/io/projectglow/sql/dsl/package.scala
+++ b/core/src/main/scala/io/projectglow/sql/dsl/package.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.projectglow.sql
+
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions._
+
+package object dsl {
+
+  def makeLambdaFunction(f: Expression => Expression): LambdaFunction = {
+    val x = UnresolvedNamedLambdaVariable(Seq("lv"))
+    LambdaFunction(f(x), Seq(x))
+  }
+
+  def makeLambdaFunction(f: (Expression, Expression) => Expression): LambdaFunction = {
+    val x = UnresolvedNamedLambdaVariable(Seq("lv1"))
+    val y = UnresolvedNamedLambdaVariable(Seq("lv2"))
+    LambdaFunction(f(x, y), Seq(x, y))
+  }
+
+  trait ImplicitOperators {
+    def expr: Expression
+    def arrayTransform(f: Expression => Expression): Expression = {
+      ArrayTransform(expr, makeLambdaFunction(f))
+    }
+    def arrayTransform(f: (Expression, Expression) => Expression): Expression = {
+      ArrayTransform(expr, makeLambdaFunction(f))
+    }
+    def filter(f: Expression => Expression): Expression = {
+      ArrayFilter(expr, makeLambdaFunction(f))
+    }
+    def filter(f: (Expression, Expression) => Expression): Expression = {
+      ArrayFilter(expr, makeLambdaFunction(f))
+    }
+    def aggregate(
+        initialValue: Expression,
+        merge: (Expression, Expression) => Expression,
+        finish: Expression => Expression = identity): Expression = {
+      ArrayAggregate(
+        expr,
+        initialValue,
+        makeLambdaFunction(merge),
+        makeLambdaFunction(finish)
+      )
+    }
+  }
+
+  implicit class GlowExpression(val expr: Expression) extends ImplicitOperators
+}

--- a/core/src/main/scala/io/projectglow/sql/dsl/package.scala
+++ b/core/src/main/scala/io/projectglow/sql/dsl/package.scala
@@ -20,7 +20,6 @@ import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.DataType
 
-
 package object dsl {
 
   trait ImplicitOperators {
@@ -46,7 +45,10 @@ package object dsl {
     def filter(f: (Expression, Expression) => Expression): Expression = {
       ArrayFilter(expr, makeLambdaFunction(f))
     }
-    def aggregate(initialValue: Expression, merge: (Expression, Expression) => Expression, finish: Expression => Expression = identity): Expression = {
+    def aggregate(
+        initialValue: Expression,
+        merge: (Expression, Expression) => Expression,
+        finish: Expression => Expression = identity): Expression = {
       ArrayAggregate(
         expr,
         initialValue,

--- a/core/src/main/scala/io/projectglow/sql/expressions/MeanSubstitute.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/MeanSubstitute.scala
@@ -66,7 +66,9 @@ case class MeanSubstitute(array: Expression, missingValue: Expression)
       // If value is missing, do not update sum and count
       stateStruct,
       // If value is not missing, add to sum and increment count
-      createNamedStruct(stateStruct.getField("sum") + arrayElement, stateStruct.getField("count") + 1)
+      createNamedStruct(
+        stateStruct.getField("sum") + arrayElement,
+        stateStruct.getField("count") + 1)
     )
   }
 

--- a/core/src/main/scala/io/projectglow/sql/expressions/MeanSubstitute.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/MeanSubstitute.scala
@@ -36,7 +36,8 @@ import io.projectglow.sql.util.RewriteAfterResolution
  *
  * If the missing value is not provided, the parameter defaults to -1.
  */
-case class MeanSubstitute(array: Expression, missingValue: Expression) extends RewriteAfterResolution {
+case class MeanSubstitute(array: Expression, missingValue: Expression)
+    extends RewriteAfterResolution {
 
   override def children: Seq[Expression] = Seq(array, missingValue)
 
@@ -104,8 +105,7 @@ case class MeanSubstitute(array: Expression, missingValue: Expression) extends R
   }
 
   override def rewrite: Expression = {
-    if (!array.dataType.isInstanceOf[ArrayType] ||
-      !arrayElementType.isInstanceOf[NumericType]) {
+    if (!array.dataType.isInstanceOf[ArrayType] || !arrayElementType.isInstanceOf[NumericType]) {
       throw SQLUtils.newAnalysisException(
         s"Can only perform mean substitution on numeric array; provided type is ${array.dataType}.")
     }
@@ -116,9 +116,6 @@ case class MeanSubstitute(array: Expression, missingValue: Expression) extends R
     }
 
     // Replace missing values with the provided strategy
-    array.arrayTransform(
-      substituteWithMean(_),
-      arrayElementType
-    )
+    array.arrayTransform(substituteWithMean(_), arrayElementType)
   }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

The mean substitution expression reused lambda variables in an unsafe way.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests