### PR TITLE
Revert "Use full ExpressionInfo constructor (#209)"

### DIFF
--- a/core/src/main/shim/3.0/SparkShim.scala
+++ b/core/src/main/shim/3.0/SparkShim.scala
@@ -30,8 +30,6 @@ object SparkShim extends SparkShimBase {
     parser.parse(input)
   }
 
-  // [SPARK-31429][SQL][DOC] Automatically generates a SQL document for built-in functions
-  // Adds 'group' argument to the ExpressionInfo constructor
   // [SPARK-27328][SQL] Add 'deprecated' in ExpressionDescription for extended usage and SQL doc
   // Adds 'deprecated' argument to the ExpressionInfo constructor
   override def createExpressionInfo(
@@ -43,17 +41,13 @@ object SparkShim extends SparkShimBase {
       examples: String,
       note: String,
       since: String): ExpressionInfo = {
+    // TODO fix this up later.
     new ExpressionInfo(
       className,
       db,
       name,
       usage,
-      arguments,
-      examples,
-      note,
-      "", // group
-      since,
-      "" // deprecated
+      arguments
     )
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This reverts commit 6bf84356724df43e13a341ba851d0c7d648fc036.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests