### PR TITLE
Support multiple-phenotype regression

### DIFF
--- a/core/src/main/scala/io/projectglow/functions.scala
+++ b/core/src/main/scala/io/projectglow/functions.scala
@@ -347,9 +347,9 @@ object functions {
    * @since 0.3.0
    *
    * @param genotypes A numeric array of genotypes
-   * @param phenotypes A numeric array of phenotypes
+   * @param phenotypes A numeric array or ``spark.ml`` ``Matrix`` of phenotypes
    * @param covariates A ``spark.ml`` ``Matrix`` of covariates
-   * @return A struct containing ``beta``, ``standardError``, and ``pValue`` fields. See :ref:`linear-regression`.
+   * @return A struct containing ``beta``, ``standardError``, and ``pValue`` fields for a single-phenotype test, and an array of such structs otherwise. See :ref:`linear-regression`.
    */
   def linear_regression_gwas(genotypes: Column, phenotypes: Column, covariates: Column): Column = withExpr {
     new io.projectglow.sql.expressions.LinearRegressionExpr(genotypes.expr, phenotypes.expr, covariates.expr)
@@ -361,10 +361,10 @@ object functions {
    * @since 0.3.0
    *
    * @param genotypes An numeric array of genotypes
-   * @param phenotypes A double array of phenotype values
+   * @param phenotypes A double array or ``spark.ml`` ``Matrix`` of phenotype values
    * @param covariates A ``spark.ml`` ``Matrix`` of covariates
    * @param test Which logistic regression test to use. Can be ``LRT`` or ``Firth``
-   * @return A struct containing ``beta``, ``oddsRatio``, ``waldConfidenceInterval``, and ``pValue`` fields. See :ref:`logistic-regression`.
+   * @return A struct containing ``beta``, ``oddsRatio``, ``waldConfidenceInterval``, and ``pValue`` fields for a single-phenotype test, and an array of such structs otherwise. See :ref:`logistic-regression`.
    */
   def logistic_regression_gwas(genotypes: Column, phenotypes: Column, covariates: Column, test: String): Column = withExpr {
     new io.projectglow.sql.expressions.LogisticRegressionExpr(genotypes.expr, phenotypes.expr, covariates.expr, Literal(test))

--- a/core/src/main/scala/io/projectglow/sql/expressions/LinearRegressionExpr.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/LinearRegressionExpr.scala
@@ -54,7 +54,7 @@ object LinearRegressionExpr {
       new DenseVector[Double](genotypes.asInstanceOf[ArrayData].toDoubleArray())
     val covariateQRContext = getState(covariates)
 
-    val results = matrixUDT.deserialize(phenotypes).toDense.rowIter.map(_.toArray).map {
+    val results = matrixUDT.deserialize(phenotypes).toDense.colIter.map(_.toArray).map {
       phenotypeArray =>
         LinearRegressionGwas.linearRegressionGwas(
           convertedGenotypes,

--- a/core/src/main/scala/io/projectglow/sql/expressions/LinearRegressionGwas.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/LinearRegressionGwas.scala
@@ -44,10 +44,10 @@ object LinearRegressionGwas extends GlowLogging {
       covariateQRContext: CovariateQRContext): RegressionStats = {
     require(
       genotypes.length == phenotypes.length,
-      "Number of samples differs between genotype and phenotype arrays")
+      s"Number of samples differs between genotype array (${genotypes.length}) and phenotype array (${phenotypes.length})")
     require(
       covariateQRContext.covQt.cols == genotypes.length,
-      "Number of samples differs between genotype array and covariate matrix")
+      s"Number of samples differs between genotype array (${genotypes.length}) and covariate matrix (${covariateQRContext.covQt.cols})")
 
     val qtx = covariateQRContext.covQt * genotypes
     val qty = covariateQRContext.covQt * phenotypes

--- a/core/src/main/scala/io/projectglow/sql/expressions/LogisticRegressionExpr.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/LogisticRegressionExpr.scala
@@ -168,7 +168,12 @@ case class LogisticRegressionExpr(
     case _ => true
   }
 
-  override def dataType: DataType = logitTest.resultSchema
+  override def dataType: DataType =
+    if (hasMultiplePhenotypes) {
+      ArrayType(logitTest.resultSchema)
+    } else {
+      logitTest.resultSchema
+    }
 
   override def inputTypes: Seq[SQLUtils.ADT] =
     Seq(

--- a/core/src/main/scala/io/projectglow/sql/expressions/glueExpressions.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/glueExpressions.scala
@@ -37,7 +37,7 @@ case class ExpandStruct(struct: Expression) extends Expression with Unevaluable 
   override def nullable: Boolean = throw new UnresolvedException(this, "nullable")
   def expand(): Seq[NamedExpression] = {
     if (!struct.dataType.isInstanceOf[StructType]) {
-      throw SQLUtils.newAnalysisException("Only structs can be expanded.")
+      throw SQLUtils.newAnalysisException(s"Only structs can be expanded, provided: ${struct.dataType}")
     }
 
     struct.dataType.asInstanceOf[StructType].zipWithIndex.map {

--- a/core/src/main/scala/org/apache/spark/sql/SQLUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/SQLUtils.scala
@@ -74,6 +74,8 @@ object SQLUtils {
 
   def anyDataType: ADT = AnyDataType
 
+  def createTypeCollection(types: ADT*): TypeCollection = TypeCollection.apply(types: _*)
+
   type ADT = AbstractDataType
 
   def getSessionExtensions(session: SparkSession): SparkSessionExtensions = {

--- a/core/src/test/scala/io/projectglow/tertiary/LinearRegressionSuite.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/LinearRegressionSuite.scala
@@ -61,8 +61,11 @@ class LinearRegressionSuite extends GlowBaseTest {
 
   def multiPhenoTestDataToOlsBaseline(testData: MultiPhenoTestData): Seq[Seq[RegressionStats]] = {
     testData.genotypes.map { g =>
-      testData.phenotypes.map { p =>
-        olsBaseline(g.toArray, p.toArray, testData.covariates.toArray)
+      testData.phenotypes.head.indices.map { pIdx =>
+        olsBaseline(
+          g.toArray,
+          testData.phenotypes.map(_.apply(pIdx)).toArray,
+          testData.covariates.toArray)
       }
     }
   }
@@ -126,8 +129,8 @@ class LinearRegressionSuite extends GlowBaseTest {
       Range(0, nSamples).map(_ => multiplier * random.nextDouble())
     }
 
-    val phenotypes = Range(0, nPhenotypes).map { _ =>
-      Range(0, nSamples).toArray.map(_ => multiplier * random.nextDouble())
+    val phenotypes = Range(0, nSamples).map { _ =>
+      Range(0, nPhenotypes).toArray.map(_ => multiplier * random.nextDouble())
     }
     val nCovariates = if (includeIntercept) nRandomCovariates + 1 else nRandomCovariates
     val covariates = Range(0, nSamples).map(_ => new Array[Double](nCovariates))
@@ -157,7 +160,7 @@ class LinearRegressionSuite extends GlowBaseTest {
       nPhenotypes = 1,
       includeIntercept = includeIntercept,
       multiplier = multiplier)
-    TestData(mptd.genotypes, mptd.phenotypes.head, mptd.covariates)
+    TestData(mptd.genotypes, mptd.phenotypes.map(_.head), mptd.covariates)
   }
 
   private def timeIt[T](opName: String)(f: => T): T = {
@@ -339,8 +342,9 @@ class LinearRegressionSuite extends GlowBaseTest {
       case (statsSeq1, statsSeq2) =>
         assert(statsSeq1.length == nPhenotypes)
         assert(statsSeq2.length == nPhenotypes)
-        statsSeq1.zip(statsSeq2).foreach { case (stats1, stats2) =>
-          compareRegressionStats(stats1, stats2)
+        statsSeq1.zip(statsSeq2).foreach {
+          case (stats1, stats2) =>
+            compareRegressionStats(stats1, stats2)
         }
     }
   }

--- a/core/src/test/scala/io/projectglow/tertiary/LogisticRegressionSuite.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/LogisticRegressionSuite.scala
@@ -197,7 +197,9 @@ class LogisticRegressionSuite extends GlowBaseTest {
 
   private val interceptOnlyV1And2 = MultiPhenoTestData(
     interceptOnlyV1.genotypes,
-    Seq(interceptOnlyV1.phenotypes.toArray, interceptOnlyV2.phenotypes.toArray),
+    interceptOnlyV1.phenotypes.zip(interceptOnlyV2.phenotypes).map {
+      case (v1, v2) => Array(v1, v2)
+    },
     interceptOnlyV1.covariates
   )
 

--- a/core/src/test/scala/io/projectglow/tertiary/RegressionTestUtils.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/RegressionTestUtils.scala
@@ -24,9 +24,19 @@ case class RegressionRow(
     phenotypes: Array[Double],
     covariates: SparkDenseMatrix)
 
+case class MultiPhenoRegressionRow(
+    genotypes: Array[Double],
+    phenotypes: SparkDenseMatrix,
+    covariates: SparkDenseMatrix)
+
 case class TestData(
     genotypes: Seq[Seq[Double]],
     phenotypes: Seq[Double],
+    covariates: Seq[Array[Double]])
+
+case class MultiPhenoTestData(
+    genotypes: Seq[Seq[Double]],
+    phenotypes: Seq[Array[Double]],
     covariates: Seq[Array[Double]])
 
 object RegressionTestUtils {
@@ -34,7 +44,8 @@ object RegressionTestUtils {
     new SparkDenseMatrix(
       input.length,
       input.head.length,
-      input(0).indices.flatMap(i => input.map(_(i))).toArray)
+      input(0).indices.flatMap(i => input.map(_(i))).toArray
+    )
   }
 
   def twoDArrayToBreezeMatrix(input: Array[Array[Double]]): BreezeDenseMatrix[Double] = {
@@ -49,6 +60,15 @@ object RegressionTestUtils {
       RegressionRow(
         g.toArray,
         testData.phenotypes.toArray,
+        twoDArrayToSparkMatrix(testData.covariates.toArray))
+    }
+  }
+
+  def multiPhenoTestDataToRows(testData: MultiPhenoTestData): Seq[MultiPhenoRegressionRow] = {
+    testData.genotypes.map { g =>
+      MultiPhenoRegressionRow(
+        g.toArray,
+        twoDArrayToSparkMatrix(testData.phenotypes.toArray),
         twoDArrayToSparkMatrix(testData.covariates.toArray))
     }
   }

--- a/docs/source/tertiary/regression-tests.rst
+++ b/docs/source/tertiary/regression-tests.rst
@@ -82,7 +82,9 @@ Parameters
 Return
 ------
 
-The function returns a struct with the following fields. The computation of each value matches the
+For a single-phenotype regression, the function returns a struct with the following fields.
+For a multiple-phenotype regression, the function returns a list of structs with the following fields.
+The computation of each value matches the
 `lm R package <https://www.rdocumentation.org/packages/stats/versions/3.6.1/topics/lm>`_.
 
 .. list-table::
@@ -176,7 +178,9 @@ parameter ``test`` to specify the hypothesis test method.
 Return
 ------
 
-The function returns a struct with the following fields. The computation of each value matches the
+For a single-phenotype regression, the function returns a struct with the following fields.
+For a multiple-phenotype regression, the function returns a list of structs with the following fields.
+The computation of each value matches the
 `glm R package <https://www.rdocumentation.org/packages/stats/versions/3.6.1/topics/glm>`_ for the
 likelihood ratio test and the
 `logistf R package <https://cran.r-project.org/web/packages/logistf/logistf.pdf>`_ for the Firth

--- a/docs/source/tertiary/regression-tests.rst
+++ b/docs/source/tertiary/regression-tests.rst
@@ -75,7 +75,7 @@ Parameters
       0th element in the ``genotypes`` array. This matrix must be constant for each row in the
       dataset. If desired, you must explicitly include an intercept covariate in this matrix.
   * - ``phenotypes``
-    - ``array<double>`` (or numeric type that can be cast to ``double``)
+    - ``array<double>`` (or numeric type that can be cast to ``double``) or ``spark.ml`` ``Matrix``
     - A numeric representation of the phenotype for each sample. This parameter may vary for each
       row in the dataset. The indexing of this array must match the ``genotypes`` and
       ``covariates`` parameters.
@@ -166,7 +166,7 @@ parameter ``test`` to specify the hypothesis test method.
       0th element in the ``genotypes`` array. This matrix must be constant for each row in the
       dataset. If desired, you must explicitly include an intercept covariate in this matrix.
   * - ``phenotypes``
-    - ``array<double>`` (or numeric type that can be cast to ``double``)
+    - ``array<double>`` (or numeric type that can be cast to ``double``) or ``spark.ml`` ``Matrix``
     - A numeric representation of the phenotype for each sample. This parameter may vary for each
       row in the dataset. The indexing of this array must match the ``genotypes`` and
       ``covariates`` parameters.

--- a/docs/source/tertiary/regression-tests.rst
+++ b/docs/source/tertiary/regression-tests.rst
@@ -77,8 +77,7 @@ Parameters
   * - ``phenotypes``
     - ``array<double>`` (or numeric type that can be cast to ``double``) or ``spark.ml`` ``Matrix``
     - A numeric representation of the phenotype for each sample. This parameter may vary for each
-      row in the dataset. The indexing of this array must match the ``genotypes`` and
-      ``covariates`` parameters.
+      row in the dataset. The indexing must match the ``genotypes`` and ``covariates`` parameters.
 
 Return
 ------
@@ -168,8 +167,7 @@ parameter ``test`` to specify the hypothesis test method.
   * - ``phenotypes``
     - ``array<double>`` (or numeric type that can be cast to ``double``) or ``spark.ml`` ``Matrix``
     - A numeric representation of the phenotype for each sample. This parameter may vary for each
-      row in the dataset. The indexing of this array must match the ``genotypes`` and
-      ``covariates`` parameters.
+      row in the dataset. The indexing must match the ``genotypes`` and ``covariates`` parameters.
   * - ``test``
     - ``string``
     - The hypothesis test method to use. Currently likelihood ratio (``LRT``) and Firth 

--- a/functions.yml
+++ b/functions.yml
@@ -423,14 +423,18 @@ gwas_functions:
           >>> df = spark.createDataFrame([Row(genotypes=genotypes, phenotypes=phenotypes, covariates=covariates)])
           >>> df.select(glow.expand_struct(glow.linear_regression_gwas('genotypes', 'phenotypes', 'covariates'))).collect()
           [Row(beta=0.9999999999999998, standardError=1.4901161193847656e-08, pValue=9.486373847239922e-09)]
+          >>> phenotypes = DenseMatrix(numRows=2, numCols=3, values=[2, 4, 3, 6, 4, 8])
+          >>> df = spark.createDataFrame([Row(genotypes=genotypes, phenotypes=phenotypes, covariates=covariates)])
+          >>> df.select(glow.linear_regression_gwas('genotypes', 'phenotypes', 'covariates').alias('results')).collect()
+          [Row(results=[Row(beta=0.9999999999999998, standardError=1.4901161193847656e-08, pValue=9.486373847239922e-09), Row(beta=1.9999999999999996, standardError=2.9802322387695312e-08, pValue=9.486373847239922e-09)])]
       args:
         - name: genotypes
           doc: A numeric array of genotypes
         - name: phenotypes
-          doc: A numeric array of phenotypes
+          doc: A numeric array or ``spark.ml`` ``Matrix`` of phenotypes
         - name: covariates
           doc: A ``spark.ml`` ``Matrix`` of covariates
-      returns: A struct containing ``beta``, ``standardError``, and ``pValue`` fields. See :ref:`linear-regression`.
+      returns: A struct containing ``beta``, ``standardError``, and ``pValue`` fields for a single-phenotype test, and an array of such structs otherwise. See :ref:`linear-regression`.
     - name: logistic_regression_gwas
       doc: Performs a logistic regression association test optimized for performance in a GWAS setting.
         See :ref:`logistic-regression` for more details.
@@ -447,17 +451,22 @@ gwas_functions:
           [Row(beta=0.7418937644793101, oddsRatio=2.09990848346903, waldConfidenceInterval=[0.2509874689201784, 17.569066925598555], pValue=0.3952193664793294)]
           >>> df.select(glow.expand_struct(glow.logistic_regression_gwas('genotypes', 'phenotypes', 'covariates', 'LRT'))).collect()
           [Row(beta=1.1658962684583645, oddsRatio=3.208797540870915, waldConfidenceInterval=[0.2970960052553798, 34.65674891673014], pValue=0.2943946848756771)]
+          >>> phenotypes = DenseMatrix(numRows=2, numCols=5, values=[1, 0, 0, 1, 0, 1, 1, 0, 1, 0])
+          >>> df = spark.createDataFrame([Row(genotypes=genotypes, phenotypes=phenotypes, covariates=covariates)])
+          >>> df.select(glow.logistic_regression_gwas('genotypes', 'phenotypes', 'covariates', 'LRT').alias('results')).collect()
+          [Row(results=[Row(beta=1.1658962684583645, oddsRatio=3.208797538802116, waldConfidenceInterval=[0.29709600522888285, 34.65674887513274], pValue=0.2943946848756769), Row(beta=-1.1658962684583645, oddsRatio=0.31164322083508966, waldConfidenceInterval=[0.028854408808020954, 3.365915335110613], pValue=0.2943946848756771)])]
+
       args:
         - name: genotypes
           doc: An numeric array of genotypes
         - name: phenotypes
-          doc: A double array of phenotype values
+          doc: A double array or ``spark.ml`` ``Matrix`` of phenotype values
         - name: covariates
           doc: A ``spark.ml`` ``Matrix`` of covariates
         - name: test
           doc: Which logistic regression test to use. Can be ``LRT`` or ``Firth``
           type: str
-      returns: A struct containing ``beta``, ``oddsRatio``, ``waldConfidenceInterval``, and ``pValue`` fields. See :ref:`logistic-regression`.
+      returns: A struct containing ``beta``, ``oddsRatio``, ``waldConfidenceInterval``, and ``pValue`` fields for a single-phenotype test, and an array of such structs otherwise. See :ref:`logistic-regression`.
     - name: genotype_states
       doc: Gets the number of alternate alleles for an array of genotype structs. Returns ``-1`` if there are any ``-1`` s (no-calls) in the calls array.
       since: 0.3.0

--- a/python/glow/functions.py
+++ b/python/glow/functions.py
@@ -546,14 +546,18 @@ def linear_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Colu
         >>> df = spark.createDataFrame([Row(genotypes=genotypes, phenotypes=phenotypes, covariates=covariates)])
         >>> df.select(glow.expand_struct(glow.linear_regression_gwas('genotypes', 'phenotypes', 'covariates'))).collect()
         [Row(beta=0.9999999999999998, standardError=1.4901161193847656e-08, pValue=9.486373847239922e-09)]
+        >>> phenotypes = DenseMatrix(numRows=2, numCols=3, values=[2, 4, 3, 6, 4, 8])
+        >>> df = spark.createDataFrame([Row(genotypes=genotypes, phenotypes=phenotypes, covariates=covariates)])
+        >>> df.select(glow.linear_regression_gwas('genotypes', 'phenotypes', 'covariates').alias('results')).collect()
+        [Row(results=[Row(beta=0.9999999999999998, standardError=1.4901161193847656e-08, pValue=9.486373847239922e-09), Row(beta=1.9999999999999996, standardError=2.9802322387695312e-08, pValue=9.486373847239922e-09)])]
 
     Args:
         genotypes : A numeric array of genotypes
-        phenotypes : A numeric array of phenotypes
+        phenotypes : A numeric array or ``spark.ml`` ``Matrix`` of phenotypes
         covariates : A ``spark.ml`` ``Matrix`` of covariates
 
     Returns:
-        A struct containing ``beta``, ``standardError``, and ``pValue`` fields. See :ref:`linear-regression`.
+        A struct containing ``beta``, ``standardError``, and ``pValue`` fields for a single-phenotype test, and an array of such structs otherwise. See :ref:`linear-regression`.
     """
     assert check_argument_types()
     output = Column(sc()._jvm.io.projectglow.functions.linear_regression_gwas(_to_java_column(genotypes), _to_java_column(phenotypes), _to_java_column(covariates)))
@@ -577,15 +581,19 @@ def logistic_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Co
         [Row(beta=0.7418937644793101, oddsRatio=2.09990848346903, waldConfidenceInterval=[0.2509874689201784, 17.569066925598555], pValue=0.3952193664793294)]
         >>> df.select(glow.expand_struct(glow.logistic_regression_gwas('genotypes', 'phenotypes', 'covariates', 'LRT'))).collect()
         [Row(beta=1.1658962684583645, oddsRatio=3.208797540870915, waldConfidenceInterval=[0.2970960052553798, 34.65674891673014], pValue=0.2943946848756771)]
+        >>> phenotypes = DenseMatrix(numRows=2, numCols=5, values=[1, 0, 0, 1, 0, 1, 1, 0, 1, 0])
+        >>> df = spark.createDataFrame([Row(genotypes=genotypes, phenotypes=phenotypes, covariates=covariates)])
+        >>> df.select(glow.logistic_regression_gwas('genotypes', 'phenotypes', 'covariates', 'LRT').alias('results')).collect()
+        [Row(results=[Row(beta=1.1658962684583645, oddsRatio=3.208797538802116, waldConfidenceInterval=[0.29709600522888285, 34.65674887513274], pValue=0.2943946848756769), Row(beta=-1.1658962684583645, oddsRatio=0.31164322083508966, waldConfidenceInterval=[0.028854408808020954, 3.365915335110613], pValue=0.2943946848756771)])]
 
     Args:
         genotypes : An numeric array of genotypes
-        phenotypes : A double array of phenotype values
+        phenotypes : A double array or ``spark.ml`` ``Matrix`` of phenotype values
         covariates : A ``spark.ml`` ``Matrix`` of covariates
         test : Which logistic regression test to use. Can be ``LRT`` or ``Firth``
 
     Returns:
-        A struct containing ``beta``, ``oddsRatio``, ``waldConfidenceInterval``, and ``pValue`` fields. See :ref:`logistic-regression`.
+        A struct containing ``beta``, ``oddsRatio``, ``waldConfidenceInterval``, and ``pValue`` fields for a single-phenotype test, and an array of such structs otherwise. See :ref:`logistic-regression`.
     """
     assert check_argument_types()
     output = Column(sc()._jvm.io.projectglow.functions.logistic_regression_gwas(_to_java_column(genotypes), _to_java_column(phenotypes), _to_java_column(covariates), test))


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Supports passing multiple phenotypes as a Spark ML matrix (eg. DenseMatrix) during regression.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
