### PR TITLE
Make it easier to run specific python tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,15 @@ Status](https://readthedocs.org/projects/glow/badge/?version=latest)](https://gl
 This project is built using [sbt](https://www.scala-sbt.org/1.0/docs/Setup.html) and Java 8.
 
 To build and run Glow, you must [install conda](https://docs.conda.io/en/latest/miniconda.html) and
-activate the environmet in `python/environment.yml`. 
+activate the environment in `python/environment.yml`. 
 ```
 conda env create -f python/environment.yml
-conda activate  glow
+conda activate glow
+```
+
+When the environment file changes, you must update the environment:
+```
+conda env update -f python/environment.yml
 ```
 
 Start an sbt shell using the `sbt` command.
@@ -84,7 +89,7 @@ python_2_11/test
 ```
 These tests will run with the same Spark classpath as the Scala 2.11 tests.
 
-To test a specific python file:
+To test a specific Python test file:
 ```
 python_2_11/pytest python/test_render_template.py
 ```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Status](https://readthedocs.org/projects/glow/badge/?version=latest)](https://gl
 # Building and Testing
 This project is built using [sbt](https://www.scala-sbt.org/1.0/docs/Setup.html) and Java 8.
 
+To build and run Glow, you must [install conda](https://docs.conda.io/en/latest/miniconda.html) and
+activate the environmet in `python/environment.yml`. 
+```
+conda env create -f python/environment.yml
+conda activate  glow
+```
+
 Start an sbt shell using the `sbt` command.
 
 > **FYI**: The following SBT projects with the suffix `2_11` are built on Scala 2.11.
@@ -71,18 +78,19 @@ To test a specific suite:
 core_2_11/testOnly *VCFDataSourceSuite
 ```
 
-To run Python tests, you must [install conda](https://docs.conda.io/en/latest/miniconda.html) and
-activate the environmet in `python/environment.yml`. 
-```
-conda env create -f python/environment.yml
-conda activate  glow
-```
-
-You can then run tests from sbt:
+To run all Python tests:
 ```
 python_2_11/test
 ```
 These tests will run with the same Spark classpath as the Scala 2.11 tests.
+
+To test a specific python file:
+```
+python_2_11/pytest python/test_render_template.py
+```
+
+When using the `pytest` key, all arguments are passed directly to the
+[pytest runner](https://docs.pytest.org/en/latest/usage.html).
 
 To run documentation tests:
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import scala.sys.process._
 
+import complete.DefaultParsers._
 import org.apache.commons.lang3.StringUtils
 import sbt.Tests._
 import sbt.Keys._
@@ -84,6 +85,7 @@ ThisBuild / generatorScript := (ThisBuild / baseDirectory).value / "python" / "r
 lazy val generatedFunctionsOutput = settingKey[File]("generatedFunctionsOutput")
 lazy val functionsTemplate = settingKey[File]("functionsTemplate")
 lazy val generateFunctions = taskKey[Seq[File]]("generateFunctions")
+lazy val pytest = inputKey[Unit]("pytest")
 
 def runCmd(args: File*): Unit = {
   args.map(_.getPath).!!
@@ -191,7 +193,18 @@ lazy val pythonSettings = Seq(
   sparkClasspath := (fullClasspath in Test).value.files.map(_.getCanonicalPath).mkString(":"),
   sparkHome := (ThisBuild / baseDirectory).value.absolutePath,
   pythonPath := ((ThisBuild / baseDirectory).value / "python").absolutePath,
-  publish / skip := true
+  publish / skip := true,
+  pytest := {
+    val args = spaceDelimited("<arg>").parsed
+    val ret = Process(
+      Seq("pytest") ++ args,
+      None,
+      "SPARK_CLASSPATH" -> sparkClasspath.value,
+      "SPARK_HOME" -> sparkHome.value,
+      "PYTHONPATH" -> pythonPath.value
+    ).!
+    require(ret == 0, "Python tests failed")
+  }
 )
 
 lazy val python =
@@ -200,14 +213,7 @@ lazy val python =
       pythonSettings,
       functionGenerationSettings,
       test in Test := {
-        // Pass the test classpath to pyspark so that we run the same bits as the Scala tests
-        val ret = Process(
-          Seq("pytest", "--doctest-modules", "python"),
-          None,
-          "SPARK_CLASSPATH" -> sparkClasspath.value,
-          "SPARK_HOME" -> sparkHome.value
-        ).!
-        require(ret == 0, "Python tests failed")
+        pytest.toTask(" --doctest-modules python").value
       },
       generatedFunctionsOutput := baseDirectory.value / "glow" / "functions.py",
       functionsTemplate := baseDirectory.value / "glow" / "functions.py.TEMPLATE",
@@ -223,15 +229,7 @@ lazy val docs = (project in file("docs"))
   .settings(
     pythonSettings,
     test in Test := {
-      // Pass the test classpath to pyspark so that we run the same bits as the Scala tests
-      val ret = Process(
-        Seq("pytest", "docs"),
-        None,
-        "SPARK_CLASSPATH" -> sparkClasspath.value,
-        "SPARK_HOME" -> sparkHome.value,
-        "PYTHONPATH" -> pythonPath.value
-      ).!
-      require(ret == 0, "Docs tests failed")
+      pytest.toTask(" docs").value
     }
   )
   .cross


### PR DESCRIPTION
## What changes are proposed in this pull request?

Expose a `pytest` key for python projects that is a thin wrapper around the `pytest` CLI. This makes it possible to run a single suite, a single test from a single suite, etc. Additionally, I consolidated the test running logic between `python` and `docs`.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
