### PR TITLE
Add yapf to format Python files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -207,26 +207,31 @@ lazy val pythonSettings = Seq(
   }
 )
 
+lazy val yapf = inputKey[Unit]("yapf")
+ThisBuild / yapf := {
+  val args = spaceDelimited("<arg>").parsed
+  val ret = Process(
+    Seq("yapf") ++ args ++ Seq(
+      "--style",
+      "python/.style.yapf",
+      "--recursive",
+      "--exclude",
+      "python/glow/functions.py",
+      "python")
+  ).!
+  require(ret == 0, "Python style tests failed")
+}
+
+val yapfAll = taskKey[Unit]("Execute the yapf task in-place for all Python files.")
+ThisBuild / yapfAll := yapf.toTask(" --in-place").value
+
 lazy val python =
   (project in file("python"))
     .settings(
       pythonSettings,
       functionGenerationSettings,
       test in Test := {
-        // Yapf style test
-        val yapfDiffs = Process(
-          Seq(
-            "yapf",
-            "--style",
-            "python/.style.yapf",
-            "--recursive",
-            "--diff",
-            "--exclude",
-            "python/glow/functions.py",
-            "python"
-          )).!
-        require(yapfDiffs == 0, "Python style tests failed")
-        // Pytest
+        yapf.toTask(" --diff").value
         pytest.toTask(" --doctest-modules python").value
       },
       generatedFunctionsOutput := baseDirectory.value / "glow" / "functions.py",

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import scala.sys.process._
 
-import complete.DefaultParsers._
 import org.apache.commons.lang3.StringUtils
 import sbt.Tests._
 import sbt.Keys._
@@ -204,10 +203,12 @@ lazy val python =
         val yapfDiffs = Process(
           Seq(
             "yapf",
+            "--style",
+            "python/.style.yapf",
             "--recursive",
-            "--exclude",
-            "'python/glow/functions.py'",
             "--diff",
+            "--exclude",
+            "python/glow/functions.py",
             "python"
           )).!
         require(yapfDiffs == 0, "Python style tests failed")

--- a/python/.style.yapf
+++ b/python/.style.yapf
@@ -1,0 +1,155 @@
+[style]
+# Align closing bracket with visual indentation.
+ALIGN_CLOSING_BRACKET_WITH_VISUAL_INDENT=True
+
+# Allow lambdas to be formatted on more than one line.
+ALLOW_MULTILINE_LAMBDAS=False
+
+# Insert a blank line before a 'def' or 'class' immediately nested
+# within another 'def' or 'class'. For example:
+#
+#   class Foo:
+#                      # <------ this blank line
+#     def method():
+#       ...
+BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF=False
+
+# Do not split consecutive brackets. Only relevant when
+# dedent_closing_brackets is set. For example:
+#
+#    call_func_that_takes_a_dict(
+#        {
+#            'key1': 'value1',
+#            'key2': 'value2',
+#        }
+#    )
+#
+# would reformat to:
+#
+#    call_func_that_takes_a_dict({
+#        'key1': 'value1',
+#        'key2': 'value2',
+#    })
+COALESCE_BRACKETS=False
+
+# The column limit.
+COLUMN_LIMIT=100
+
+# Indent width used for line continuations.
+CONTINUATION_INDENT_WIDTH=4
+
+# Put closing brackets on a separate line, dedented, if the bracketed
+# expression can't fit in a single line. Applies to all kinds of brackets,
+# including function definitions and calls. For example:
+#
+#   config = {
+#       'key1': 'value1',
+#       'key2': 'value2',
+#   }        # <--- this bracket is dedented and on a separate line
+#
+#   time_series = self.remote_client.query_entity_counters(
+#       entity='dev3246.region1',
+#       key='dns.query_latency_tcp',
+#       transform=Transformation.AVERAGE(window=timedelta(seconds=60)),
+#       start_ts=now()-timedelta(days=3),
+#       end_ts=now(),
+#   )        # <--- this bracket is dedented and on a separate line
+DEDENT_CLOSING_BRACKETS=False
+
+# The regex for an i18n comment. The presence of this comment stops
+# reformatting of that line, because the comments are required to be
+# next to the string they translate.
+I18N_COMMENT=
+
+# The i18n function call names. The presence of this function stops
+# reformattting on that line, because the string it has cannot be moved
+# away from the i18n comment.
+I18N_FUNCTION_CALL=
+
+# Indent the dictionary value if it cannot fit on the same line as the
+# dictionary key. For example:
+#
+#   config = {
+#       'key1':
+#           'value1',
+#       'key2': value1 +
+#               value2,
+#   }
+INDENT_DICTIONARY_VALUE=False
+
+# Don't split dictionary keys and values with a new line
+ALLOW_SPLIT_BEFORE_DICT_VALUE=False
+
+# The number of columns to use for indentation.
+INDENT_WIDTH=4
+
+# Join short lines into one line. E.g., single line 'if' statements.
+JOIN_MULTIPLE_LINES=True
+
+# Use spaces around the power operator.
+SPACES_AROUND_POWER_OPERATOR=False
+
+# The number of spaces required before a trailing comment.
+SPACES_BEFORE_COMMENT=2
+
+# Insert a space between the ending comma and closing bracket of a list,
+# etc.
+SPACE_BETWEEN_ENDING_COMMA_AND_CLOSING_BRACKET=True
+
+# Split before arguments if the argument list is terminated by a
+# comma.
+SPLIT_ARGUMENTS_WHEN_COMMA_TERMINATED=True
+
+# Set to True to prefer splitting before '&', '|' or '^' rather than
+# after.
+SPLIT_BEFORE_BITWISE_OPERATOR=False
+
+# If an argument / parameter list is going to be split, then split before
+# the first argument.
+SPLIT_BEFORE_FIRST_ARGUMENT=False
+
+# Set to True to prefer splitting before 'and' or 'or' rather than
+# after.
+SPLIT_BEFORE_LOGICAL_OPERATOR=False
+
+# Split named assignments onto individual lines.
+SPLIT_BEFORE_NAMED_ASSIGNS=True
+
+# The penalty for splitting right after the opening bracket.
+SPLIT_PENALTY_AFTER_OPENING_BRACKET=30
+
+# The penalty for splitting the line after a unary operator.
+SPLIT_PENALTY_AFTER_UNARY_OPERATOR=10000
+
+# The penalty for splitting right before an if expression.
+SPLIT_PENALTY_BEFORE_IF_EXPR=0
+
+# The penalty of splitting the line around the '&', '|', and '^'
+# operators.
+SPLIT_PENALTY_BITWISE_OPERATOR=300
+
+# The penalty for characters over the column limit.
+SPLIT_PENALTY_EXCESS_CHARACTER=2600
+
+# The penalty incurred by adding a line split to the unwrapped line. The
+# more line splits added the higher the penalty.
+SPLIT_PENALTY_FOR_ADDED_LINE_SPLIT=30
+
+# The penalty of splitting a list of "import as" names. For example:
+#
+#   from a_very_long_or_indented_module_name_yada_yad import (long_argument_1,
+#                                                             long_argument_2,
+#                                                             long_argument_3)
+#
+# would reformat to something like:
+#
+#   from a_very_long_or_indented_module_name_yada_yad import (
+#       long_argument_1, long_argument_2, long_argument_3)
+SPLIT_PENALTY_IMPORT_NAMES=0
+
+# The penalty of splitting the line around the 'and' and 'or'
+# operators.
+SPLIT_PENALTY_LOGICAL_OPERATOR=300
+
+# Use the Tab character for indentation.
+USE_TABS=False

--- a/python/environment.yml
+++ b/python/environment.yml
@@ -22,3 +22,4 @@ dependencies:
     - Sphinx-Substitution-Extensions==2019.6.15.0 # Substitutions in code blocks
     - sphinx-tabs==1.1.13 # Code tabs (Python/Scala)
     - sybil==1.2.0 # Automatic doctest
+    - yapf==0.30.0

--- a/python/glow/conftest.py
+++ b/python/glow/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from pyspark.sql import functions, Row
 import glow
 
+
 @pytest.fixture(autouse=True)
 def add_spark(doctest_namespace, spark):
     glow.register(spark)
@@ -10,4 +11,3 @@ def add_spark(doctest_namespace, spark):
     doctest_namespace['lit'] = functions.lit
     doctest_namespace['col'] = functions.col
     doctest_namespace['glow'] = glow
-

--- a/python/glow/functions.py
+++ b/python/glow/functions.py
@@ -6,10 +6,13 @@ from pyspark.sql.column import Column, _to_java_column, _to_seq
 from typeguard import check_argument_types, check_return_type
 from typing import Union
 
+
 def sc():
     return SparkContext._active_spark_context
 
+
 ########### complex_type_manipulation
+
 
 def add_struct_fields(struct: Union[Column, str], *fields: Union[Column, str]) -> Column:
     """
@@ -30,7 +33,8 @@ def add_struct_fields(struct: Union[Column, str], *fields: Union[Column, str]) -
         A struct consisting of the input struct and the added fields
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.add_struct_fields(_to_java_column(struct), _to_seq(sc(), fields, _to_java_column)))
+    output = Column(sc()._jvm.io.projectglow.functions.add_struct_fields(
+        _to_java_column(struct), _to_seq(sc(), fields, _to_java_column)))
     assert check_return_type(output)
     return output
 
@@ -173,7 +177,8 @@ def subset_struct(struct: Union[Column, str], *fields: str) -> Column:
         A struct containing only the indicated fields
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.subset_struct(_to_java_column(struct), _to_seq(sc(), fields)))
+    output = Column(sc()._jvm.io.projectglow.functions.subset_struct(_to_java_column(struct),
+                                                                     _to_seq(sc(), fields)))
     assert check_return_type(output)
     return output
 
@@ -201,9 +206,14 @@ def vector_to_array(vector: Union[Column, str]) -> Column:
     assert check_return_type(output)
     return output
 
+
 ########### etl
 
-def hard_calls(probabilities: Union[Column, str], numAlts: Union[Column, str], phased: Union[Column, str], threshold: float = None) -> Column:
+
+def hard_calls(probabilities: Union[Column, str],
+               numAlts: Union[Column, str],
+               phased: Union[Column, str],
+               threshold: float = None) -> Column:
     """
     Converts an array of probabilities to hard calls. The probabilities are assumed to be diploid. See :ref:`variant-data-transformations` for more details.
 
@@ -232,14 +242,21 @@ def hard_calls(probabilities: Union[Column, str], numAlts: Union[Column, str], p
     """
     assert check_argument_types()
     if threshold is None:
-        output = Column(sc()._jvm.io.projectglow.functions.hard_calls(_to_java_column(probabilities), _to_java_column(numAlts), _to_java_column(phased)))
+        output = Column(sc()._jvm.io.projectglow.functions.hard_calls(
+            _to_java_column(probabilities), _to_java_column(numAlts), _to_java_column(phased)))
     else:
-        output = Column(sc()._jvm.io.projectglow.functions.hard_calls(_to_java_column(probabilities), _to_java_column(numAlts), _to_java_column(phased), threshold))
+        output = Column(sc()._jvm.io.projectglow.functions.hard_calls(
+            _to_java_column(probabilities), _to_java_column(numAlts), _to_java_column(phased),
+            threshold))
     assert check_return_type(output)
     return output
 
 
-def lift_over_coordinates(contigName: Union[Column, str], start: Union[Column, str], end: Union[Column, str], chainFile: str, minMatchRatio: float = None) -> Column:
+def lift_over_coordinates(contigName: Union[Column, str],
+                          start: Union[Column, str],
+                          end: Union[Column, str],
+                          chainFile: str,
+                          minMatchRatio: float = None) -> Column:
     """
     Performs liftover for the coordinates of a variant. To perform liftover of alleles and add additional metadata, see :ref:`liftover`.
 
@@ -267,14 +284,19 @@ def lift_over_coordinates(contigName: Union[Column, str], start: Union[Column, s
     """
     assert check_argument_types()
     if minMatchRatio is None:
-        output = Column(sc()._jvm.io.projectglow.functions.lift_over_coordinates(_to_java_column(contigName), _to_java_column(start), _to_java_column(end), chainFile))
+        output = Column(sc()._jvm.io.projectglow.functions.lift_over_coordinates(
+            _to_java_column(contigName), _to_java_column(start), _to_java_column(end), chainFile))
     else:
-        output = Column(sc()._jvm.io.projectglow.functions.lift_over_coordinates(_to_java_column(contigName), _to_java_column(start), _to_java_column(end), chainFile, minMatchRatio))
+        output = Column(sc()._jvm.io.projectglow.functions.lift_over_coordinates(
+            _to_java_column(contigName), _to_java_column(start), _to_java_column(end), chainFile,
+            minMatchRatio))
     assert check_return_type(output)
     return output
 
 
-def normalize_variant(contigName: Union[Column, str], start: Union[Column, str], end: Union[Column, str], refAllele: Union[Column, str], altAlleles: Union[Column, str], refGenomePathString: str) -> Column:
+def normalize_variant(contigName: Union[Column, str], start: Union[Column, str],
+                      end: Union[Column, str], refAllele: Union[Column, str],
+                      altAlleles: Union[Column, str], refGenomePathString: str) -> Column:
     """
     Normalizes the variant with a behavior similar to vt normalize or bcftools norm.
     Creates a StructType column including the normalized ``start``, ``end``, ``referenceAllele`` and
@@ -311,7 +333,9 @@ def normalize_variant(contigName: Union[Column, str], start: Union[Column, str],
         A struct as explained above
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.normalize_variant(_to_java_column(contigName), _to_java_column(start), _to_java_column(end), _to_java_column(refAllele), _to_java_column(altAlleles), refGenomePathString))
+    output = Column(sc()._jvm.io.projectglow.functions.normalize_variant(
+        _to_java_column(contigName), _to_java_column(start), _to_java_column(end),
+        _to_java_column(refAllele), _to_java_column(altAlleles), refGenomePathString))
     assert check_return_type(output)
     return output
 
@@ -341,11 +365,14 @@ def mean_substitute(array: Union[Column, str], missingValue: Union[Column, str] 
     if missingValue is None:
         output = Column(sc()._jvm.io.projectglow.functions.mean_substitute(_to_java_column(array)))
     else:
-        output = Column(sc()._jvm.io.projectglow.functions.mean_substitute(_to_java_column(array), _to_java_column(missingValue)))
+        output = Column(sc()._jvm.io.projectglow.functions.mean_substitute(
+            _to_java_column(array), _to_java_column(missingValue)))
     assert check_return_type(output)
     return output
 
+
 ########### quality_control
+
 
 def call_summary_stats(genotypes: Union[Column, str]) -> Column:
     """
@@ -366,7 +393,8 @@ def call_summary_stats(genotypes: Union[Column, str]) -> Column:
         A struct containing ``callRate``, ``nCalled``, ``nUncalled``, ``nHet``, ``nHomozygous``, ``nNonRef``, ``nAllelesCalled``, ``alleleCounts``, ``alleleFrequencies`` fields. See :ref:`variant-qc`.
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.call_summary_stats(_to_java_column(genotypes)))
+    output = Column(sc()._jvm.io.projectglow.functions.call_summary_stats(
+        _to_java_column(genotypes)))
     assert check_return_type(output)
     return output
 
@@ -448,7 +476,8 @@ def gq_summary_stats(genotypes: Union[Column, str]) -> Column:
     return output
 
 
-def sample_call_summary_stats(genotypes: Union[Column, str], refAllele: Union[Column, str], alternateAlleles: Union[Column, str]) -> Column:
+def sample_call_summary_stats(genotypes: Union[Column, str], refAllele: Union[Column, str],
+                              alternateAlleles: Union[Column, str]) -> Column:
     """
     Computes per-sample call summary statistics. See :ref:`sample-qc` for more details.
 
@@ -472,7 +501,8 @@ def sample_call_summary_stats(genotypes: Union[Column, str], refAllele: Union[Co
         A struct containing ``sampleId``, ``callRate``, ``nCalled``, ``nUncalled``, ``nHomRef``, ``nHet``, ``nHomVar``, ``nSnp``, ``nInsertion``, ``nDeletion``, ``nTransition``, ``nTransversion``, ``nSpanningDeletion``, ``rTiTv``, ``rInsertionDeletion``, ``rHetHomVar`` fields. See :ref:`sample-qc`.
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.sample_call_summary_stats(_to_java_column(genotypes), _to_java_column(refAllele), _to_java_column(alternateAlleles)))
+    output = Column(sc()._jvm.io.projectglow.functions.sample_call_summary_stats(
+        _to_java_column(genotypes), _to_java_column(refAllele), _to_java_column(alternateAlleles)))
     assert check_return_type(output)
     return output
 
@@ -499,7 +529,8 @@ def sample_dp_summary_stats(genotypes: Union[Column, str]) -> Column:
         An array of structs where each struct contains ``mean``, ``stDev``, ``min``, and ``max`` of the genotype depths for a sample. If ``sampleId`` is present in a genotype, it will be propagated to the resulting struct as an extra field.
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.sample_dp_summary_stats(_to_java_column(genotypes)))
+    output = Column(sc()._jvm.io.projectglow.functions.sample_dp_summary_stats(
+        _to_java_column(genotypes)))
     assert check_return_type(output)
     return output
 
@@ -526,13 +557,17 @@ def sample_gq_summary_stats(genotypes: Union[Column, str]) -> Column:
         An array of structs where each struct contains ``mean``, ``stDev``, ``min``, and ``max`` of the genotype qualities for a sample. If ``sampleId`` is present in a genotype, it will be propagated to the resulting struct as an extra field.
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.sample_gq_summary_stats(_to_java_column(genotypes)))
+    output = Column(sc()._jvm.io.projectglow.functions.sample_gq_summary_stats(
+        _to_java_column(genotypes)))
     assert check_return_type(output)
     return output
 
+
 ########### gwas_functions
 
-def linear_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Column, str], covariates: Union[Column, str]) -> Column:
+
+def linear_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Column, str],
+                           covariates: Union[Column, str]) -> Column:
     """
     Performs a linear regression association test optimized for performance in a GWAS setting. See :ref:`linear-regression` for details.
 
@@ -556,12 +591,14 @@ def linear_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Colu
         A struct containing ``beta``, ``standardError``, and ``pValue`` fields. See :ref:`linear-regression`.
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.linear_regression_gwas(_to_java_column(genotypes), _to_java_column(phenotypes), _to_java_column(covariates)))
+    output = Column(sc()._jvm.io.projectglow.functions.linear_regression_gwas(
+        _to_java_column(genotypes), _to_java_column(phenotypes), _to_java_column(covariates)))
     assert check_return_type(output)
     return output
 
 
-def logistic_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Column, str], covariates: Union[Column, str], test: str) -> Column:
+def logistic_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Column, str],
+                             covariates: Union[Column, str], test: str) -> Column:
     """
     Performs a logistic regression association test optimized for performance in a GWAS setting. See :ref:`logistic-regression` for more details.
 
@@ -588,7 +625,8 @@ def logistic_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Co
         A struct containing ``beta``, ``oddsRatio``, ``waldConfidenceInterval``, and ``pValue`` fields. See :ref:`logistic-regression`.
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.logistic_regression_gwas(_to_java_column(genotypes), _to_java_column(phenotypes), _to_java_column(covariates), test))
+    output = Column(sc()._jvm.io.projectglow.functions.logistic_regression_gwas(
+        _to_java_column(genotypes), _to_java_column(phenotypes), _to_java_column(covariates), test))
     assert check_return_type(output)
     return output
 
@@ -619,4 +657,3 @@ def genotype_states(genotypes: Union[Column, str]) -> Column:
     output = Column(sc()._jvm.io.projectglow.functions.genotype_states(_to_java_column(genotypes)))
     assert check_return_type(output)
     return output
-

--- a/python/glow/functions.py
+++ b/python/glow/functions.py
@@ -6,13 +6,10 @@ from pyspark.sql.column import Column, _to_java_column, _to_seq
 from typeguard import check_argument_types, check_return_type
 from typing import Union
 
-
 def sc():
     return SparkContext._active_spark_context
 
-
 ########### complex_type_manipulation
-
 
 def add_struct_fields(struct: Union[Column, str], *fields: Union[Column, str]) -> Column:
     """
@@ -33,8 +30,7 @@ def add_struct_fields(struct: Union[Column, str], *fields: Union[Column, str]) -
         A struct consisting of the input struct and the added fields
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.add_struct_fields(
-        _to_java_column(struct), _to_seq(sc(), fields, _to_java_column)))
+    output = Column(sc()._jvm.io.projectglow.functions.add_struct_fields(_to_java_column(struct), _to_seq(sc(), fields, _to_java_column)))
     assert check_return_type(output)
     return output
 
@@ -177,8 +173,7 @@ def subset_struct(struct: Union[Column, str], *fields: str) -> Column:
         A struct containing only the indicated fields
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.subset_struct(_to_java_column(struct),
-                                                                     _to_seq(sc(), fields)))
+    output = Column(sc()._jvm.io.projectglow.functions.subset_struct(_to_java_column(struct), _to_seq(sc(), fields)))
     assert check_return_type(output)
     return output
 
@@ -206,14 +201,9 @@ def vector_to_array(vector: Union[Column, str]) -> Column:
     assert check_return_type(output)
     return output
 
-
 ########### etl
 
-
-def hard_calls(probabilities: Union[Column, str],
-               numAlts: Union[Column, str],
-               phased: Union[Column, str],
-               threshold: float = None) -> Column:
+def hard_calls(probabilities: Union[Column, str], numAlts: Union[Column, str], phased: Union[Column, str], threshold: float = None) -> Column:
     """
     Converts an array of probabilities to hard calls. The probabilities are assumed to be diploid. See :ref:`variant-data-transformations` for more details.
 
@@ -242,21 +232,14 @@ def hard_calls(probabilities: Union[Column, str],
     """
     assert check_argument_types()
     if threshold is None:
-        output = Column(sc()._jvm.io.projectglow.functions.hard_calls(
-            _to_java_column(probabilities), _to_java_column(numAlts), _to_java_column(phased)))
+        output = Column(sc()._jvm.io.projectglow.functions.hard_calls(_to_java_column(probabilities), _to_java_column(numAlts), _to_java_column(phased)))
     else:
-        output = Column(sc()._jvm.io.projectglow.functions.hard_calls(
-            _to_java_column(probabilities), _to_java_column(numAlts), _to_java_column(phased),
-            threshold))
+        output = Column(sc()._jvm.io.projectglow.functions.hard_calls(_to_java_column(probabilities), _to_java_column(numAlts), _to_java_column(phased), threshold))
     assert check_return_type(output)
     return output
 
 
-def lift_over_coordinates(contigName: Union[Column, str],
-                          start: Union[Column, str],
-                          end: Union[Column, str],
-                          chainFile: str,
-                          minMatchRatio: float = None) -> Column:
+def lift_over_coordinates(contigName: Union[Column, str], start: Union[Column, str], end: Union[Column, str], chainFile: str, minMatchRatio: float = None) -> Column:
     """
     Performs liftover for the coordinates of a variant. To perform liftover of alleles and add additional metadata, see :ref:`liftover`.
 
@@ -284,19 +267,14 @@ def lift_over_coordinates(contigName: Union[Column, str],
     """
     assert check_argument_types()
     if minMatchRatio is None:
-        output = Column(sc()._jvm.io.projectglow.functions.lift_over_coordinates(
-            _to_java_column(contigName), _to_java_column(start), _to_java_column(end), chainFile))
+        output = Column(sc()._jvm.io.projectglow.functions.lift_over_coordinates(_to_java_column(contigName), _to_java_column(start), _to_java_column(end), chainFile))
     else:
-        output = Column(sc()._jvm.io.projectglow.functions.lift_over_coordinates(
-            _to_java_column(contigName), _to_java_column(start), _to_java_column(end), chainFile,
-            minMatchRatio))
+        output = Column(sc()._jvm.io.projectglow.functions.lift_over_coordinates(_to_java_column(contigName), _to_java_column(start), _to_java_column(end), chainFile, minMatchRatio))
     assert check_return_type(output)
     return output
 
 
-def normalize_variant(contigName: Union[Column, str], start: Union[Column, str],
-                      end: Union[Column, str], refAllele: Union[Column, str],
-                      altAlleles: Union[Column, str], refGenomePathString: str) -> Column:
+def normalize_variant(contigName: Union[Column, str], start: Union[Column, str], end: Union[Column, str], refAllele: Union[Column, str], altAlleles: Union[Column, str], refGenomePathString: str) -> Column:
     """
     Normalizes the variant with a behavior similar to vt normalize or bcftools norm.
     Creates a StructType column including the normalized ``start``, ``end``, ``referenceAllele`` and
@@ -333,9 +311,7 @@ def normalize_variant(contigName: Union[Column, str], start: Union[Column, str],
         A struct as explained above
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.normalize_variant(
-        _to_java_column(contigName), _to_java_column(start), _to_java_column(end),
-        _to_java_column(refAllele), _to_java_column(altAlleles), refGenomePathString))
+    output = Column(sc()._jvm.io.projectglow.functions.normalize_variant(_to_java_column(contigName), _to_java_column(start), _to_java_column(end), _to_java_column(refAllele), _to_java_column(altAlleles), refGenomePathString))
     assert check_return_type(output)
     return output
 
@@ -365,14 +341,11 @@ def mean_substitute(array: Union[Column, str], missingValue: Union[Column, str] 
     if missingValue is None:
         output = Column(sc()._jvm.io.projectglow.functions.mean_substitute(_to_java_column(array)))
     else:
-        output = Column(sc()._jvm.io.projectglow.functions.mean_substitute(
-            _to_java_column(array), _to_java_column(missingValue)))
+        output = Column(sc()._jvm.io.projectglow.functions.mean_substitute(_to_java_column(array), _to_java_column(missingValue)))
     assert check_return_type(output)
     return output
 
-
 ########### quality_control
-
 
 def call_summary_stats(genotypes: Union[Column, str]) -> Column:
     """
@@ -393,8 +366,7 @@ def call_summary_stats(genotypes: Union[Column, str]) -> Column:
         A struct containing ``callRate``, ``nCalled``, ``nUncalled``, ``nHet``, ``nHomozygous``, ``nNonRef``, ``nAllelesCalled``, ``alleleCounts``, ``alleleFrequencies`` fields. See :ref:`variant-qc`.
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.call_summary_stats(
-        _to_java_column(genotypes)))
+    output = Column(sc()._jvm.io.projectglow.functions.call_summary_stats(_to_java_column(genotypes)))
     assert check_return_type(output)
     return output
 
@@ -476,8 +448,7 @@ def gq_summary_stats(genotypes: Union[Column, str]) -> Column:
     return output
 
 
-def sample_call_summary_stats(genotypes: Union[Column, str], refAllele: Union[Column, str],
-                              alternateAlleles: Union[Column, str]) -> Column:
+def sample_call_summary_stats(genotypes: Union[Column, str], refAllele: Union[Column, str], alternateAlleles: Union[Column, str]) -> Column:
     """
     Computes per-sample call summary statistics. See :ref:`sample-qc` for more details.
 
@@ -501,8 +472,7 @@ def sample_call_summary_stats(genotypes: Union[Column, str], refAllele: Union[Co
         A struct containing ``sampleId``, ``callRate``, ``nCalled``, ``nUncalled``, ``nHomRef``, ``nHet``, ``nHomVar``, ``nSnp``, ``nInsertion``, ``nDeletion``, ``nTransition``, ``nTransversion``, ``nSpanningDeletion``, ``rTiTv``, ``rInsertionDeletion``, ``rHetHomVar`` fields. See :ref:`sample-qc`.
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.sample_call_summary_stats(
-        _to_java_column(genotypes), _to_java_column(refAllele), _to_java_column(alternateAlleles)))
+    output = Column(sc()._jvm.io.projectglow.functions.sample_call_summary_stats(_to_java_column(genotypes), _to_java_column(refAllele), _to_java_column(alternateAlleles)))
     assert check_return_type(output)
     return output
 
@@ -529,8 +499,7 @@ def sample_dp_summary_stats(genotypes: Union[Column, str]) -> Column:
         An array of structs where each struct contains ``mean``, ``stDev``, ``min``, and ``max`` of the genotype depths for a sample. If ``sampleId`` is present in a genotype, it will be propagated to the resulting struct as an extra field.
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.sample_dp_summary_stats(
-        _to_java_column(genotypes)))
+    output = Column(sc()._jvm.io.projectglow.functions.sample_dp_summary_stats(_to_java_column(genotypes)))
     assert check_return_type(output)
     return output
 
@@ -557,17 +526,13 @@ def sample_gq_summary_stats(genotypes: Union[Column, str]) -> Column:
         An array of structs where each struct contains ``mean``, ``stDev``, ``min``, and ``max`` of the genotype qualities for a sample. If ``sampleId`` is present in a genotype, it will be propagated to the resulting struct as an extra field.
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.sample_gq_summary_stats(
-        _to_java_column(genotypes)))
+    output = Column(sc()._jvm.io.projectglow.functions.sample_gq_summary_stats(_to_java_column(genotypes)))
     assert check_return_type(output)
     return output
 
-
 ########### gwas_functions
 
-
-def linear_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Column, str],
-                           covariates: Union[Column, str]) -> Column:
+def linear_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Column, str], covariates: Union[Column, str]) -> Column:
     """
     Performs a linear regression association test optimized for performance in a GWAS setting. See :ref:`linear-regression` for details.
 
@@ -591,14 +556,12 @@ def linear_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Colu
         A struct containing ``beta``, ``standardError``, and ``pValue`` fields. See :ref:`linear-regression`.
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.linear_regression_gwas(
-        _to_java_column(genotypes), _to_java_column(phenotypes), _to_java_column(covariates)))
+    output = Column(sc()._jvm.io.projectglow.functions.linear_regression_gwas(_to_java_column(genotypes), _to_java_column(phenotypes), _to_java_column(covariates)))
     assert check_return_type(output)
     return output
 
 
-def logistic_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Column, str],
-                             covariates: Union[Column, str], test: str) -> Column:
+def logistic_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Column, str], covariates: Union[Column, str], test: str) -> Column:
     """
     Performs a logistic regression association test optimized for performance in a GWAS setting. See :ref:`logistic-regression` for more details.
 
@@ -625,8 +588,7 @@ def logistic_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Co
         A struct containing ``beta``, ``oddsRatio``, ``waldConfidenceInterval``, and ``pValue`` fields. See :ref:`logistic-regression`.
     """
     assert check_argument_types()
-    output = Column(sc()._jvm.io.projectglow.functions.logistic_regression_gwas(
-        _to_java_column(genotypes), _to_java_column(phenotypes), _to_java_column(covariates), test))
+    output = Column(sc()._jvm.io.projectglow.functions.logistic_regression_gwas(_to_java_column(genotypes), _to_java_column(phenotypes), _to_java_column(covariates), test))
     assert check_return_type(output)
     return output
 
@@ -657,3 +619,4 @@ def genotype_states(genotypes: Union[Column, str]) -> Column:
     output = Column(sc()._jvm.io.projectglow.functions.genotype_states(_to_java_column(genotypes)))
     assert check_return_type(output)
     return output
+

--- a/python/glow/glow.py
+++ b/python/glow/glow.py
@@ -4,7 +4,9 @@ from typing import Dict
 from typeguard import check_argument_types, check_return_type
 
 
-def transform(operation: str, df: DataFrame, arg_map: Dict[str, str]=None,
+def transform(operation: str,
+              df: DataFrame,
+              arg_map: Dict[str, str] = None,
               **kwargs: str) -> DataFrame:
     """
     Apply a named transformation to a DataFrame of genomic data. All parameters apart from the input
@@ -37,6 +39,7 @@ def transform(operation: str, df: DataFrame, arg_map: Dict[str, str]=None,
 
     assert check_return_type(output_df)
     return output_df
+
 
 def register(session: SparkSession):
     """

--- a/python/glow/tests/test_register.py
+++ b/python/glow/tests/test_register.py
@@ -10,7 +10,9 @@ def test_no_register(spark):
     row_two = Row(Row(str_col='bar', int_col=2, bool_col=False))
     df = sess.createDataFrame([row_one, row_two], schema=['base_col'])
     with pytest.raises(AnalysisException):
-        df.selectExpr("add_struct_fields(base_col, 'float_col', 3.14, 'rev_str_col', reverse(base_col.str_col))").head()
+        df.selectExpr(
+            "add_struct_fields(base_col, 'float_col', 3.14, 'rev_str_col', reverse(base_col.str_col))"
+        ).head()
 
 
 def test_register(spark):

--- a/python/glow/tests/test_transform.py
+++ b/python/glow/tests/test_transform.py
@@ -7,8 +7,12 @@ import glow
 def test_transform(spark):
     df = spark.read.format("vcf")\
         .load("test-data/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf")
-    converted = glow.transform("pipe", df, input_formatter="vcf", output_formatter="vcf",
-                             cmd='["cat"]', in_vcf_header="infer")
+    converted = glow.transform("pipe",
+                               df,
+                               input_formatter="vcf",
+                               output_formatter="vcf",
+                               cmd='["cat"]',
+                               in_vcf_header="infer")
     assert converted.count() == 1075
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,21 +3,19 @@ import imp
 
 version = imp.load_source('version', 'version.py').VERSION
 
-setup(
-    name='glow.py',
-    version=version,
-    packages=['glow'],
-    install_requires=[
-        'typeguard==2.5.0',
-    ],
-    author='The Glow Authors',
-    description='An open-source toolkit for large-scale genomic analysis',
-    long_description=open('README.rst').read(),
-    long_description_content_type='text/x-rst',
-    license='Apache License 2.0',
-    classifiers=[
-        'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3.7',
-    ],
-    url='https://projectglow.io'
-)
+setup(name='glow.py',
+      version=version,
+      packages=['glow'],
+      install_requires=[
+          'typeguard==2.5.0',
+      ],
+      author='The Glow Authors',
+      description='An open-source toolkit for large-scale genomic analysis',
+      long_description=open('README.rst').read(),
+      long_description_content_type='text/x-rst',
+      license='Apache License 2.0',
+      classifiers=[
+          'Intended Audience :: Developers',
+          'Programming Language :: Python :: 3.7',
+      ],
+      url='https://projectglow.io')

--- a/python/test_render_template.py
+++ b/python/test_render_template.py
@@ -1,28 +1,56 @@
 import pytest
 import render_template as rt
 
+
 def test_validate_optional_arg():
-    groups = { 'test': { 'functions': [ { 'args': [ { 'name': 'bad', 'is_optional': True }, { 'name':
-        'ok' } ], 'since': '1.0', 'doc': 'doc', 'expr_class': 'class'} ] } }
+    groups = {
+        'test': {
+            'functions': [{
+                'args': [{
+                    'name': 'bad',
+                    'is_optional': True
+                }, {
+                    'name': 'ok'
+                }],
+                'since': '1.0',
+                'doc': 'doc',
+                'expr_class': 'class'
+            }]
+        }
+    }
     with pytest.raises(AssertionError) as error:
         rt.prepare_definitions(groups)
         assert 'optional' in error.value
 
+
 def test_validate_var_args():
-    groups = { 'test': { 'functions': [ { 'args': [ { 'name': 'bad', 'is_var_args': True }, { 'name':
-        'ok' } ], 'since': '1.0', 'doc': 'doc', 'expr_class': 'class'} ] } }
+    groups = {
+        'test': {
+            'functions': [{
+                'args': [{
+                    'name': 'bad',
+                    'is_var_args': True
+                }, {
+                    'name': 'ok'
+                }],
+                'since': '1.0',
+                'doc': 'doc',
+                'expr_class': 'class'
+            }]
+        }
+    }
     with pytest.raises(AssertionError) as error:
         rt.prepare_definitions(groups)
         assert 'var args' in error.value
 
+
 def test_check_field_defined():
-    base_func = { 'name': 'function', 'doc': 'doc', 'since': '1.0', 'expr_class': 'class' }
+    base_func = {'name': 'function', 'doc': 'doc', 'since': '1.0', 'expr_class': 'class'}
     fields = ['name', 'doc', 'since', 'expr_class']
     for f in fields:
         new_func = base_func.copy()
         del new_func[f]
-        groups = { 'test': { 'functions': [new_func] } }
+        groups = {'test': {'functions': [new_func]}}
         with pytest.raises(AssertionError) as error:
             rt.prepare_definitions(groups)
             assert f in error.value
-


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds yapf to check Python style. To format in place, call `sbt yapfAll`.

## How is this patch tested?
- [ ] Unit tests
- [x] Integration tests
- [ ] Manual tests