### PR TITLE
Generate inferred alphas

### DIFF
--- a/python/glow/wgr/linear_model/ridge_model.py
+++ b/python/glow/wgr/linear_model/ridge_model.py
@@ -31,16 +31,16 @@ class RidgeReducer:
     block with L columns to begin with will be reduced to a block with K columns, where each column is the prediction
     of one ridge model for one target label.
     """
-    def __init__(self, alphas: NDArray[(Any, ), Float]) -> None:
+    def __init__(self, alphas: NDArray[(Any, ), Float] = np.array([])) -> None:
         """
         RidgeReducer is initialized with a list of alpha values.
 
         Args:
-            alphas : array_like of alpha values used in the ridge reduction
+            alphas : array_like of alpha values used in the ridge reduction (optional).
         """
         if not (alphas >= 0).all():
             raise Exception('Alpha values must all be non-negative.')
-        self.alphas = {f'alpha_{i}': a for i, a in enumerate(alphas)}
+        self.alphas = create_alpha_dict(alphas)
 
     def fit(
         self,
@@ -69,6 +69,8 @@ class RidgeReducer:
         if 'label' in blockdf.columns:
             map_key_pattern.append('label')
             reduce_key_pattern.append('label')
+        if not self.alphas:
+            self.alphas = generate_alphas(blockdf)
 
         map_udf = pandas_udf(
             lambda key, pdf: map_normal_eqn(key, map_key_pattern, pdf, labeldf, sample_blocks, covdf
@@ -163,16 +165,16 @@ class RidgeRegression:
     coefficients.  The optimal ridge alpha value is chosen for each label by maximizing the average out of fold r2
     score.
     """
-    def __init__(self, alphas: NDArray[(Any, ), Float]) -> None:
+    def __init__(self, alphas: NDArray[(Any, ), Float] = np.array([])) -> None:
         """
         RidgeRegression is initialized with a list of alpha values.
 
         Args:
-            alphas : array_like of alpha values used in the ridge regression
+            alphas : array_like of alpha values used in the ridge regression (optional).
         """
         if not (alphas >= 0).all():
             raise Exception('Alpha values must all be non-negative.')
-        self.alphas = {f'alpha_{i}': a for i, a in enumerate(alphas)}
+        self.alphas = create_alpha_dict(alphas)
 
     def fit(
         self,
@@ -200,6 +202,9 @@ class RidgeRegression:
 
         map_key_pattern = ['sample_block', 'label']
         reduce_key_pattern = ['header_block', 'header', 'label']
+
+        if not self.alphas:
+            self.alphas = generate_alphas(blockdf)
 
         map_udf = pandas_udf(
             lambda key, pdf: map_normal_eqn(key, map_key_pattern, pdf, labeldf, sample_blocks, covdf

--- a/python/glow/wgr/linear_model/tests/test_functions.py
+++ b/python/glow/wgr/linear_model/tests/test_functions.py
@@ -15,6 +15,7 @@
 from glow.wgr.linear_model.functions import *
 import numpy as np
 import pandas as pd
+from pyspark.sql import Row
 import pytest
 
 
@@ -58,3 +59,18 @@ def test_assemble_block_zero_sig():
     df = pd.DataFrame({'mu': [0.2, 0], 'sig': [0.1, 0], 'values': [[0.1, 0.3], [0, 0]]})
     with pytest.raises(ValueError):
         assemble_block(n_rows=2, n_cols=2, pdf=df, cov_matrix=np.array([[]]))
+
+
+def test_generate_alphas(spark):
+    df = spark.createDataFrame(
+        [Row(header='header_one'),
+         Row(header='header_one'),
+         Row(header='header_two')])
+    expected_alphas = {
+        'alpha_0': np.float(2 / 0.99),
+        'alpha_1': np.float(2 / 0.75),
+        'alpha_2': np.float(2 / 0.5),
+        'alpha_3': np.float(2 / 0.25),
+        'alpha_4': np.float(2 / 0.01)
+    }
+    assert generate_alphas(df) == expected_alphas


### PR DESCRIPTION
From @karenfeng:

## What changes are proposed in this pull request?

In the case that the user does not know which `alpha` values to provide (eg. based on heritability estimates), we should support automatically generating them. These values do not work well in the case that the phenotypes are not on the scale of 1.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests
