### PR TITLE
Add tests that regex's tolerate chromosomes with underscores

### DIFF
--- a/python/glow/wgr/linear_model/ridge_model.py
+++ b/python/glow/wgr/linear_model/ridge_model.py
@@ -341,18 +341,7 @@ class RidgeRegression:
             chromosome; the columns are indexed by label. The column types are float64. The DataFrame is sorted using
             chromosome as the primary sort key, and sample ID as the secondary sort key.
         """
-        # Regex captures the chromosome name in the header
-        # level 1 header: chr_3_block_8_alpha_0_label_sim100
-        # level 2 header: chr_3_alpha_0_label_sim100
-        if chromosomes:
-            loco_chromosomes = chromosomes
-        else:
-            loco_chromosomes = [
-                r.chromosome for r in blockdf.select(
-                    f.regexp_extract('header', r"^chr_(.+?)_(alpha|block)", 1).alias(
-                        'chromosome')).distinct().collect()
-            ]
-            print(f'Transforming with a LOCO approach against {loco_chromosomes}')
+        loco_chromosomes = chromosomes if chromosomes else infer_chromosomes(blockdf)
         loco_chromosomes.sort()
 
         all_y_hat_df = pd.DataFrame({})

--- a/python/glow/wgr/linear_model/tests/test_functions.py
+++ b/python/glow/wgr/linear_model/tests/test_functions.py
@@ -120,9 +120,9 @@ def test_check_covars_unit_stddev(spark):
 
 
 def test_new_headers_one_level(spark):
-    (new_header_block, sort_keys, headers) = new_headers('chr_decoy_1_block_10', ['alpha_1', 'alpha_2'],
-                                                         [('alpha_1', 'sim1'), ('alpha_1', 'sim2'),
-                                                          ('alpha_2', 'sim1'), ('alpha_2', 'sim2')])
+    (new_header_block, sort_keys, headers) = new_headers(
+        'chr_decoy_1_block_10', ['alpha_1', 'alpha_2'], [('alpha_1', 'sim1'), ('alpha_1', 'sim2'),
+                                                         ('alpha_2', 'sim1'), ('alpha_2', 'sim2')])
     assert new_header_block == 'chr_decoy_1'
     assert sort_keys == [10 * 2 + 1, 10 * 2 + 1, 10 * 2 + 2, 10 * 2 + 2]
     assert headers == [
@@ -137,10 +137,12 @@ def test_new_headers_two_level(spark):
                                                           ('alpha_2', 'sim1'), ('alpha_2', 'sim2')])
     assert new_header_block == 'all'
     contig_hash = abs(hash('decoy_1')) % (10**8)
-    assert sort_keys == [contig_hash * 2 + 1, contig_hash * 2 + 1, contig_hash * 2 + 2, contig_hash * 2 + 2]
+    assert sort_keys == [
+        contig_hash * 2 + 1, contig_hash * 2 + 1, contig_hash * 2 + 2, contig_hash * 2 + 2
+    ]
     assert headers == [
-        'chr_decoy_1_alpha_1_label_sim1', 'chr_decoy_1_alpha_1_label_sim2', 'chr_decoy_1_alpha_2_label_sim1',
-        'chr_decoy_1_alpha_2_label_sim2'
+        'chr_decoy_1_alpha_1_label_sim1', 'chr_decoy_1_alpha_1_label_sim2',
+        'chr_decoy_1_alpha_2_label_sim1', 'chr_decoy_1_alpha_2_label_sim2'
     ]
 
 
@@ -154,11 +156,13 @@ def test_new_headers_three_levels(spark):
         'alpha_1_label_sim1', 'alpha_1_label_sim2', 'alpha_2_label_sim1', 'alpha_2_label_sim2'
     ]
 
+
 def test_infer_chromosomes(spark):
-    df = spark.createDataFrame(
-        [Row(header='chr_3_block_8_alpha_0_label_sim100'),
-         Row(header='chr_3_alpha_0_label_sim100'),
-         Row(header='chr_X_alpha_0_label_sim100'),
-         Row(header='chr_decoy_1_block_8_alpha_0_label_sim100'),
-         Row(header='chr_decoy_2_alpha_0_label_sim100')])
+    df = spark.createDataFrame([
+        Row(header='chr_3_block_8_alpha_0_label_sim100'),
+        Row(header='chr_3_alpha_0_label_sim100'),
+        Row(header='chr_X_alpha_0_label_sim100'),
+        Row(header='chr_decoy_1_block_8_alpha_0_label_sim100'),
+        Row(header='chr_decoy_2_alpha_0_label_sim100')
+    ])
     assert sorted(infer_chromosomes(df)) == ['3', 'X', 'decoy_1', 'decoy_2']

--- a/python/glow/wgr/linear_model/tests/test_functions.py
+++ b/python/glow/wgr/linear_model/tests/test_functions.py
@@ -120,27 +120,27 @@ def test_check_covars_unit_stddev(spark):
 
 
 def test_new_headers_one_level(spark):
-    (new_header_block, sort_keys, headers) = new_headers('chr_X_block_10', ['alpha_1', 'alpha_2'],
+    (new_header_block, sort_keys, headers) = new_headers('chr_decoy_1_block_10', ['alpha_1', 'alpha_2'],
                                                          [('alpha_1', 'sim1'), ('alpha_1', 'sim2'),
                                                           ('alpha_2', 'sim1'), ('alpha_2', 'sim2')])
-    assert new_header_block == 'chr_X'
+    assert new_header_block == 'chr_decoy_1'
     assert sort_keys == [10 * 2 + 1, 10 * 2 + 1, 10 * 2 + 2, 10 * 2 + 2]
     assert headers == [
-        'chr_X_block_10_alpha_1_label_sim1', 'chr_X_block_10_alpha_1_label_sim2',
-        'chr_X_block_10_alpha_2_label_sim1', 'chr_X_block_10_alpha_2_label_sim2'
+        'chr_decoy_1_block_10_alpha_1_label_sim1', 'chr_decoy_1_block_10_alpha_1_label_sim2',
+        'chr_decoy_1_block_10_alpha_2_label_sim1', 'chr_decoy_1_block_10_alpha_2_label_sim2'
     ]
 
 
 def test_new_headers_two_level(spark):
-    (new_header_block, sort_keys, headers) = new_headers('chr_X', ['alpha_1', 'alpha_2'],
+    (new_header_block, sort_keys, headers) = new_headers('chr_decoy_1', ['alpha_1', 'alpha_2'],
                                                          [('alpha_1', 'sim1'), ('alpha_1', 'sim2'),
                                                           ('alpha_2', 'sim1'), ('alpha_2', 'sim2')])
     assert new_header_block == 'all'
-    hash_X = abs(hash('X')) % (10**8)
-    assert sort_keys == [hash_X * 2 + 1, hash_X * 2 + 1, hash_X * 2 + 2, hash_X * 2 + 2]
+    contig_hash = abs(hash('decoy_1')) % (10**8)
+    assert sort_keys == [contig_hash * 2 + 1, contig_hash * 2 + 1, contig_hash * 2 + 2, contig_hash * 2 + 2]
     assert headers == [
-        'chr_X_alpha_1_label_sim1', 'chr_X_alpha_1_label_sim2', 'chr_X_alpha_2_label_sim1',
-        'chr_X_alpha_2_label_sim2'
+        'chr_decoy_1_alpha_1_label_sim1', 'chr_decoy_1_alpha_1_label_sim2', 'chr_decoy_1_alpha_2_label_sim1',
+        'chr_decoy_1_alpha_2_label_sim2'
     ]
 
 
@@ -153,3 +153,12 @@ def test_new_headers_three_levels(spark):
     assert headers == [
         'alpha_1_label_sim1', 'alpha_1_label_sim2', 'alpha_2_label_sim1', 'alpha_2_label_sim2'
     ]
+
+def test_infer_chromosomes(spark):
+    df = spark.createDataFrame(
+        [Row(header='chr_3_block_8_alpha_0_label_sim100'),
+         Row(header='chr_3_alpha_0_label_sim100'),
+         Row(header='chr_X_alpha_0_label_sim100'),
+         Row(header='chr_decoy_1_block_8_alpha_0_label_sim100'),
+         Row(header='chr_decoy_2_alpha_0_label_sim100')])
+    assert sorted(infer_chromosomes(df)) == ['3', 'X', 'decoy_1', 'decoy_2']


### PR DESCRIPTION
## What changes are proposed in this pull request?

Follows up on https://github.com/projectglow/glow/pull/242, with a minor refactor and a check that the added regex's are tolerant for chromosomes with underscores.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests