### PR TITLE
Pass new Hadoop configuration in BigFileDatasource

### DIFF
--- a/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
+++ b/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
@@ -43,10 +43,10 @@ abstract class BigFileDatasource extends CreatableRelationProvider {
   protected def serializeDataFrame(options: Map[String, String], df: DataFrame): RDD[Array[Byte]]
 
   override def createRelation(
-                               sqlContext: SQLContext,
-                               mode: SaveMode,
-                               options: Map[String, String],
-                               data: DataFrame): BaseRelation = {
+    sqlContext: SQLContext,
+    mode: SaveMode,
+    options: Map[String, String],
+    data: DataFrame): BaseRelation = {
 
     val path = BigFileDatasource.checkPath(options)
     val filesystemPath = new Path(path)
@@ -87,7 +87,6 @@ case class SingleFileRelation(sqlContext: SQLContext, schema: StructType) extend
 
 trait BigFileUploader {
   def canUpload(path: String, conf: Configuration): Boolean
-
   def upload(bytes: RDD[Array[Byte]], path: String, conf: Configuration): Unit
 }
 
@@ -118,7 +117,6 @@ object SingleFileWriter extends GlowLogging {
   }
 
   private def writeFileFromDriver(path: Path, byteRdd: RDD[Array[Byte]], hadoopConf: Configuration): Unit = {
-    val sc = byteRdd.sparkContext
     val fs = path.getFileSystem(hadoopConf)
     WithUtils.withCloseable(fs.create(path)) { stream =>
       WithUtils.withCachedRDD(byteRdd) { cachedRdd =>

--- a/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
+++ b/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
@@ -87,7 +87,7 @@ case class SingleFileRelation(sqlContext: SQLContext, schema: StructType) extend
 
 trait BigFileUploader {
   def canUpload(path: String, conf: Configuration): Boolean
-  def upload(bytes: RDD[Array[Byte]], path: String): Unit
+  def upload(bytes: RDD[Array[Byte]], path: String, conf: Configuration): Unit
 }
 
 object SingleFileWriter extends GlowLogging {
@@ -112,7 +112,7 @@ object SingleFileWriter extends GlowLogging {
       case Some(uploader) => uploader.upload(rdd, path, hadoopConf)
       case None =>
         logger.info(s"Could not find a parallel uploader for $path, uploading from the driver")
-        writeFileFromDriver(new Path(uri), rdd)
+        writeFileFromDriver(new Path(uri), rdd, hadoopConf)
     }
   }
 

--- a/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
+++ b/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
@@ -86,7 +86,7 @@ object BigFileDatasource {
 case class SingleFileRelation(sqlContext: SQLContext, schema: StructType) extends BaseRelation
 
 trait BigFileUploader {
-  def canUpload(conf: Configuration, path: String): Boolean
+  def canUpload(path: String, conf: Configuration): Boolean
   def upload(bytes: RDD[Array[Byte]], path: String): Unit
 }
 

--- a/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
+++ b/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
@@ -43,10 +43,10 @@ abstract class BigFileDatasource extends CreatableRelationProvider {
   protected def serializeDataFrame(options: Map[String, String], df: DataFrame): RDD[Array[Byte]]
 
   override def createRelation(
-      sqlContext: SQLContext,
-      mode: SaveMode,
-      options: Map[String, String],
-      data: DataFrame): BaseRelation = {
+                               sqlContext: SQLContext,
+                               mode: SaveMode,
+                               options: Map[String, String],
+                               data: DataFrame): BaseRelation = {
 
     val path = BigFileDatasource.checkPath(options)
     val filesystemPath = new Path(path)
@@ -87,6 +87,7 @@ case class SingleFileRelation(sqlContext: SQLContext, schema: StructType) extend
 
 trait BigFileUploader {
   def canUpload(path: String, conf: Configuration): Boolean
+
   def upload(bytes: RDD[Array[Byte]], path: String, conf: Configuration): Unit
 }
 
@@ -103,7 +104,7 @@ object SingleFileWriter extends GlowLogging {
    *
    * Infers the destination storage system from the provided path.
    *
-   * @param rdd The RDD to write.
+   * @param rdd  The RDD to write.
    * @param path The path to write the RDD to.
    */
   def write(rdd: RDD[Array[Byte]], path: String, hadoopConf: Configuration) {

--- a/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
+++ b/core/src/main/scala/io/projectglow/sql/BigFileDatasource.scala
@@ -43,10 +43,10 @@ abstract class BigFileDatasource extends CreatableRelationProvider {
   protected def serializeDataFrame(options: Map[String, String], df: DataFrame): RDD[Array[Byte]]
 
   override def createRelation(
-    sqlContext: SQLContext,
-    mode: SaveMode,
-    options: Map[String, String],
-    data: DataFrame): BaseRelation = {
+      sqlContext: SQLContext,
+      mode: SaveMode,
+      options: Map[String, String],
+      data: DataFrame): BaseRelation = {
 
     val path = BigFileDatasource.checkPath(options)
     val filesystemPath = new Path(path)
@@ -116,7 +116,10 @@ object SingleFileWriter extends GlowLogging {
     }
   }
 
-  private def writeFileFromDriver(path: Path, byteRdd: RDD[Array[Byte]], hadoopConf: Configuration): Unit = {
+  private def writeFileFromDriver(
+      path: Path,
+      byteRdd: RDD[Array[Byte]],
+      hadoopConf: Configuration): Unit = {
     val fs = path.getFileSystem(hadoopConf)
     WithUtils.withCloseable(fs.create(path)) { stream =>
       WithUtils.withCachedRDD(byteRdd) { cachedRdd =>

--- a/core/src/test/resources/META-INF/services/io.projectglow.sql.BigFileUploader
+++ b/core/src/test/resources/META-INF/services/io.projectglow.sql.BigFileUploader
@@ -1,1 +1,2 @@
 io.projectglow.sql.DummyFileUploader
+io.projectglow.sql.BigFileDatasourceSuiteFileUploader


### PR DESCRIPTION
## What changes are proposed in this pull request?

To match the behavior in Spark, we should be creating a new Hadoop configuration: https://github.com/apache/spark/blob/9331a5c44baa79998625829e9be624e8564c91ea/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/DataSource.scala#L113
This allows the user to pass configurations via the Spark runtime configurations (`spark.config`) or the writer options, rather than directly manipulating the Spark hadoop configs.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests