### PR TITLE
Faster conversion from python double array to java

### DIFF
--- a/core/src/main/scala/io/projectglow/common/PythonUtils.scala
+++ b/core/src/main/scala/io/projectglow/common/PythonUtils.scala
@@ -1,0 +1,19 @@
+package io.projectglow.common
+
+import java.io.ByteArrayInputStream
+import java.nio.ByteBuffer
+
+import org.apache.spark.ml.linalg.DenseMatrix
+
+object PythonUtils {
+  def doubleArrayFromBytes(len: Int, bytes: Array[Byte]): Array[Double] = {
+    val buffer = ByteBuffer.wrap(bytes)
+    val out = new Array[Double](len)
+    var i = 0
+    while (i < len) {
+      out(i) = buffer.getDouble()
+      i += 1
+    }
+    out
+  }
+}

--- a/core/src/main/scala/io/projectglow/common/PythonUtils.scala
+++ b/core/src/main/scala/io/projectglow/common/PythonUtils.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectglow.common
 
 import java.io.ByteArrayInputStream

--- a/python/glow/conversions.py
+++ b/python/glow/conversions.py
@@ -35,10 +35,10 @@ def _convert_numpy_to_java_array(np_arr: np.ndarray) -> JavaArray:
     assert np_arr.dtype.type == np.double
 
     sc = SparkContext._active_spark_context
-    java_arr = sc._gateway.new_array(sc._jvm.double, np_arr.shape[0])
-    for idx, ele in enumerate(np_arr):
-        java_arr[idx] = ele.item()
-
+    size = np_arr.shape[0]
+    # Convert to big endian and serialize
+    byte_arr = np.ascontiguousarray(np_arr, '>d').tobytes()
+    java_arr = sc._jvm.io.projectglow.common.PythonUtils.doubleArrayFromBytes(size, byte_arr)
     assert check_return_type(java_arr)
     return java_arr
 


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
The current method turns out to be quite slow. When I tried on a 5M sample dataset, converting a 10 col covariate matrix took over 10 minutes (I stopped waiting after that). This method is much faster because it only requires a single call between Python and Java.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

- Verified that this works with large sample sizes on a cluster
- Timed locally:
```
def test_timing(spark):
    arr = np.random.rand(10000)
    d = dict(globals())
    d.update(locals())
    print(timeit.timeit('_convert_numpy_to_java_array(arr)', globals=d, number=100))
    print(timeit.timeit('_convert_numpy_to_java_array_old(arr)', globals=d, number=100))
```

Output:
```
0.445821821
101.61667800699999
```
