### PR TITLE
Default build to Spark 3.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,19 +17,14 @@ install_conda_deps: &install_conda_deps
       fi
 
 
-install_pyspark3: &install_pyspark3
-  run: # Evict PySpark 2.4.3 in favor of PySpark 3.0
+install_pyspark2: &install_pyspark2
+  run: # Evict PySpark 3.0.0 in favor of PySpark 2.4.5
     name: Install PySpark 3
     command: |
       export PATH=$HOME/conda/bin:$PATH
       source activate glow
       conda remove -y pyspark
-      git clone --depth 1 --branch branch-3.0 https://github.com/apache/spark.git
-      cd spark/python
-      mv setup.py old-setup.py
-      mv ~/glow/pyspark-setup.py setup.py
-      python setup.py sdist
-      pip install dist/pyspark-3.0.*.tar.gz
+      pip install pyspark==2.4.5
 
 check_clean_repo: &check_clean_repo
   run:
@@ -81,12 +76,13 @@ jobs:
       - save_cache:
           paths:
             - /home/circleci/conda
-          key: conda-deps-v1-{{ checksum "python/environment.yml" }}
+      - *install_pyspark2
       - run:
           name: Run Scala tests
           environment:
           command: |
             export PATH=$HOME/conda/envs/glow/bin:$PATH
+            export SPARK_VERSION="2.4.5"
             export SCALA_VERSION="2.11.12"
             sbt coverage core/test coverageReport exit
       - run:
@@ -95,6 +91,7 @@ jobs:
           environment:
           command: |
             export PATH=$HOME/conda/envs/glow/bin:$PATH
+            export SPARK_VERSION="2.4.5"
             export SCALA_VERSION="2.11.12"
             sbt python/test exit
       - run:
@@ -102,6 +99,7 @@ jobs:
           environment:
           command: |
             export PATH=$HOME/conda/envs/glow/bin:$PATH
+            export SPARK_VERSION="2.4.5"
             export SCALA_VERSION="2.11.12"
             sbt docs/test exit
       - *check_clean_repo
@@ -125,11 +123,13 @@ jobs:
           paths:
             - /home/circleci/conda
           key: conda-deps-v1-{{ checksum "python/environment.yml" }}
+      - *install_pyspark2
       - run:
           name: Run Scala tests
           environment:
           command: |
             export PATH=$HOME/conda/envs/glow/bin:$PATH
+            export SPARK_VERSION="2.4.5"
             export SCALA_VERSION="2.12.8"
             sbt core/test exit
       - run:
@@ -138,6 +138,7 @@ jobs:
           environment:
           command: |
             export PATH=$HOME/conda/envs/glow/bin:$PATH
+            export SPARK_VERSION="2.4.5"
             export SCALA_VERSION="2.12.8"
             sbt python/test exit
       - run:
@@ -145,14 +146,10 @@ jobs:
           environment:
           command: |
             export PATH=$HOME/conda/envs/glow/bin:$PATH
+            export SPARK_VERSION="2.4.5"
             export SCALA_VERSION="2.12.8"
             sbt docs/test exit
-      - *check_clean_repo
-      - store_artifacts:
-          path: ~/glow/unit-tests.log
-          destination: unit-tests.log
-      - store_test_results:
-          path: ~/glow/core/target/scala-2.12/test-reports
+
 
   spark-3-tests:
     <<: *setup_base
@@ -166,13 +163,12 @@ jobs:
           paths:
             - /home/circleci/conda
           key: conda-deps-v1-{{ checksum "python/environment.yml" }}
-      - *install_pyspark3
       - run:
           name: Run Scala tests
           environment:
           command: |
             export PATH=$HOME/conda/envs/glow/bin:$PATH
-            export SPARK_VERSION="3.0.1-SNAPSHOT"
+            export SPARK_VERSION="3.0.0"
             export SCALA_VERSION="2.12.8"
             sbt core/test exit
       - run:
@@ -181,7 +177,7 @@ jobs:
           environment:
           command: |
             export PATH=$HOME/conda/envs/glow/bin:$PATH
-            export SPARK_VERSION="3.0.1-SNAPSHOT"
+            export SPARK_VERSION="3.0.0"
             export SCALA_VERSION="2.12.8"
             sbt python/test exit
       - run:
@@ -189,9 +185,15 @@ jobs:
           environment:
           command: |
             export PATH=$HOME/conda/envs/glow/bin:$PATH
-            export SPARK_VERSION="3.0.1-SNAPSHOT"
+            export SPARK_VERSION="3.0.0"
             export SCALA_VERSION="2.12.8"
             sbt docs/test exit
+      - *check_clean_repo
+      - store_artifacts:
+          path: ~/glow/unit-tests.log
+          destination: unit-tests.log
+      - store_test_results:
+          path: ~/glow/core/target/scala-2.12/test-reports
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,7 @@ jobs:
       - save_cache:
           paths:
             - /home/circleci/conda
+          key: conda-deps-v1-{{ checksum "python/environment.yml" }}
       - *install_pyspark2
       - run:
           name: Run Scala tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ install_conda_deps: &install_conda_deps
 
 install_pyspark2: &install_pyspark2
   run: # Evict PySpark 3.0.0 in favor of PySpark 2.4.5
-    name: Install PySpark 3
+    name: Install PySpark 2.4.5
     command: |
       export PATH=$HOME/conda/bin:$PATH
       source activate glow

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ import sbt.nio.Keys._
 lazy val scala212 = "2.12.8"
 lazy val scala211 = "2.11.12"
 
-lazy val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "2.4.3")
+lazy val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "3.0.0")
 
 def majorMinorVersion(version: String): String = {
   StringUtils.ordinalIndexOf(version, ".", 2) match {

--- a/python/environment.yml
+++ b/python/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - pandas=0.25.3
   - pip
   - pyarrow=0.15.1
-  - pyspark=2.4.5
+  - pyspark=3.0.0
   - pytest
   - pyyaml
   - sphinx


### PR DESCRIPTION
## What changes are proposed in this pull request?

Sets the default build (locally and on CI/CD) to depend on Spark 3.0.0, which is now in GA.

## How is this patch tested?
- [x] Unit tests
- [x] Integration tests
- [ ] Manual tests
