### PR TITLE
Use SQL context from input DataFrame in transformer

### DIFF
--- a/python/glow/glow.py
+++ b/python/glow/glow.py
@@ -48,11 +48,10 @@ def transform(operation: str,
     """
     assert check_argument_types()
 
-    sc = SparkContext.getOrCreate(0)
     transform_fn = SparkContext._jvm.io.projectglow.Glow.transform
     args = arg_map if arg_map is not None else kwargs
     output_jdf = transform_fn(operation, df._jdf, args)
-    output_df = DataFrame(output_jdf, SQLContext.getOrCreate(sc))
+    output_df = DataFrame(output_jdf, df.sql_ctx)
 
     assert check_return_type(output_df)
     return output_df


### PR DESCRIPTION
## What changes are proposed in this pull request?

`SQLContext.getOrCreate` is deprecated in Spark 3.0.0. This PR removes our usage of this API in the Glow transformer, as we can use the one in the input DataFrame.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

`test_transform.py` should cover this.