### PR TITLE
Non-compressed VCFs should be splitable

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -67,7 +67,8 @@ class VCFFileFormat extends TextBasedFileFormat with DataSourceRegister with Hls
 
     // Note: we check if a file is gzipped vs block gzipped during reading, so this will be true
     // for .gz files even if they aren't actually splittable
-    codecFactory.getCodec(path).isInstanceOf[SplittableCompressionCodec]
+    val codec = codecFactory.getCodec(path)
+    codec == null || codecFactory.getCodec(path).isInstanceOf[SplittableCompressionCodec]
   }
 
   override def inferSchema(

--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -59,16 +59,17 @@ class VCFFileFormat extends TextBasedFileFormat with DataSourceRegister with Hls
       sparkSession: SparkSession,
       options: Map[String, String],
       path: Path): Boolean = {
-    if (codecFactory == null) {
-      codecFactory = new CompressionCodecFactory(
-        VCFFileFormat.hadoopConfWithBGZ(sparkSession.sessionState.newHadoopConf())
-      )
-    }
+    super.isSplitable(sparkSession, options, path) || {
+      if (codecFactory == null) {
+        codecFactory = new CompressionCodecFactory(
+          VCFFileFormat.hadoopConfWithBGZ(sparkSession.sessionState.newHadoopConf())
+        )
+      }
 
-    // Note: we check if a file is gzipped vs block gzipped during reading, so this will be true
-    // for .gz files even if they aren't actually splittable
-    val codec = codecFactory.getCodec(path)
-    codec == null || codecFactory.getCodec(path).isInstanceOf[SplittableCompressionCodec]
+      // Note: we check if a file is gzipped vs block gzipped during reading, so this will be true
+      // for .gz files even if they aren't actually splittable
+      codecFactory.getCodec(path).isInstanceOf[SplittableCompressionCodec]
+    }
   }
 
   override def inferSchema(

--- a/core/src/test/scala/io/projectglow/vcf/VCFDatasourceSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/VCFDatasourceSuite.scala
@@ -535,6 +535,12 @@ class VCFDatasourceSuite extends GlowBaseTest {
     assert(csvFormat.isSplitable(spark, Map.empty, bgzPath))
   }
 
+  test("uncompressed files are splitable") {
+    val path = new Path(s"$testDataHome/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf")
+    val vcfFormat = new VCFFileFormat()
+    assert(vcfFormat.isSplitable(spark, Map.empty, path))
+  }
+
   test("Tolerate lower-case nan's") {
     val sess = spark
     import sess.implicits._


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
We missed this bit when we forked `TextBasedFileFormat`'s splitability conditions.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
