### PR TITLE
Generate alphas with label-free headers

### DIFF
--- a/docs/source/tertiary/whole-genome-regression.rst
+++ b/docs/source/tertiary/whole-genome-regression.rst
@@ -298,8 +298,8 @@ Example
 -------
 
 If alpha values are not provided, they will be generated during ``RidgeRegression.fit`` based on the unique number of
-headers *h* in the blocked genotype matrix *X1*, and a set of heritability values. These are only sensible if the
-phenotypes are on the scale of one.
+label-free headers *h* in the reduced blocked genotype matrix *X1*, and a set of heritability values. These are only
+sensible if the phenotypes are on the scale of one.
 
 .. math::
 

--- a/python/glow/wgr/linear_model/functions.py
+++ b/python/glow/wgr/linear_model/functions.py
@@ -268,7 +268,8 @@ def generate_alphas(blockdf: DataFrame) -> Dict[str, Float]:
     Returns:
         Dict of [alpha names, alpha values]
     """
-    num_label_free_headers = blockdf.select(f.regexp_extract('header', r"^(.+?)($|_label_.*)", 1)).distinct().count()
+    num_label_free_headers = blockdf.select(f.regexp_extract('header', r"^(.+?)($|_label_.*)",
+                                                             1)).distinct().count()
     heritability_vals = [0.99, 0.75, 0.50, 0.25, 0.01]
     alphas = np.array([num_label_free_headers / h for h in heritability_vals])
     print(f"Generated alphas: {alphas}")

--- a/python/glow/wgr/linear_model/functions.py
+++ b/python/glow/wgr/linear_model/functions.py
@@ -259,7 +259,7 @@ def create_alpha_dict(alphas: NDArray[(Any, ), Float]) -> Dict[str, Float]:
 @typechecked
 def generate_alphas(blockdf: DataFrame) -> Dict[str, Float]:
     """
-    Generates alpha values using a range of heritability values and the number of headers.
+    Generates alpha values using a range of heritability values and the number of distinct headers (without labels).
 
     Args:
         blockdf : Spark DataFrame representing a block matrix
@@ -268,9 +268,9 @@ def generate_alphas(blockdf: DataFrame) -> Dict[str, Float]:
     Returns:
         Dict of [alpha names, alpha values]
     """
-    num_headers = blockdf.select('header').distinct().count()
+    num_label_free_headers = blockdf.select(f.regexp_extract('header', r"^(.+?)(_label)?", 1)).distinct().count()
     heritability_vals = [0.99, 0.75, 0.50, 0.25, 0.01]
-    alphas = np.array([num_headers / h for h in heritability_vals])
+    alphas = np.array([num_label_free_headers / h for h in heritability_vals])
     print(f"Generated alphas: {alphas}")
     return create_alpha_dict(alphas)
 

--- a/python/glow/wgr/linear_model/functions.py
+++ b/python/glow/wgr/linear_model/functions.py
@@ -268,7 +268,7 @@ def generate_alphas(blockdf: DataFrame) -> Dict[str, Float]:
     Returns:
         Dict of [alpha names, alpha values]
     """
-    num_label_free_headers = blockdf.select(f.regexp_extract('header', r"^(.+?)(_label)?", 1)).distinct().count()
+    num_label_free_headers = blockdf.select(f.regexp_extract('header', r"^(.+?)($|_label_.*)", 1)).distinct().count()
     heritability_vals = [0.99, 0.75, 0.50, 0.25, 0.01]
     alphas = np.array([num_label_free_headers / h for h in heritability_vals])
     print(f"Generated alphas: {alphas}")

--- a/python/glow/wgr/linear_model/tests/test_functions.py
+++ b/python/glow/wgr/linear_model/tests/test_functions.py
@@ -64,9 +64,10 @@ def test_assemble_block_zero_sig():
 
 def test_generate_alphas(spark):
     df = spark.createDataFrame(
-        [Row(header='header_one'),
-         Row(header='header_one'),
-         Row(header='header_two')])
+        [Row(header='chr_3_block_8_alpha_0_label_sim1'),
+         Row(header='chr_3_block_8_alpha_0_label_sim2'),
+         Row(header='chr_3_block_8_alpha_1'),
+         Row(header='chr_3_block_8_alpha_1_label_sim1')])
     expected_alphas = {
         'alpha_0': np.float(2 / 0.99),
         'alpha_1': np.float(2 / 0.75),

--- a/python/glow/wgr/linear_model/tests/test_functions.py
+++ b/python/glow/wgr/linear_model/tests/test_functions.py
@@ -63,11 +63,12 @@ def test_assemble_block_zero_sig():
 
 
 def test_generate_alphas(spark):
-    df = spark.createDataFrame(
-        [Row(header='chr_3_block_8_alpha_0_label_sim1'),
-         Row(header='chr_3_block_8_alpha_0_label_sim2'),
-         Row(header='chr_3_block_8_alpha_1'),
-         Row(header='chr_3_block_8_alpha_1_label_sim1')])
+    df = spark.createDataFrame([
+        Row(header='chr_3_block_8_alpha_0_label_sim1'),
+        Row(header='chr_3_block_8_alpha_0_label_sim2'),
+        Row(header='chr_3_block_8_alpha_1'),
+        Row(header='chr_3_block_8_alpha_1_label_sim1')
+    ])
     expected_alphas = {
         'alpha_0': np.float(2 / 0.99),
         'alpha_1': np.float(2 / 0.75),


### PR DESCRIPTION
## What changes are proposed in this pull request?

Addresses #260 by generating alphas based on the number of unique headers with the labels removed.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests