### PR TITLE
Update sybil dependency

### DIFF
--- a/python/environment.yml
+++ b/python/environment.yml
@@ -22,6 +22,6 @@ dependencies:
     - twine==2.0.0 # Pypi publishing
     - Sphinx-Substitution-Extensions==2019.6.15.0 # Substitutions in code blocks
     - sphinx-tabs==1.1.13 # Code tabs (Python/Scala)
-    - sybil==1.2.0 # Automatic doctest
+    - sybil==1.4.0 # Automatic doctest
     - yapf==0.30.0
     - nptyping==1.1.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

[pytest 6.0.0 treats deprecation warnings as errors by default](https://github.com/pytest-dev/pytest/issues/5584), and old versions of sybil used an API [deprecated in pytest 5.4.0](https://github.com/pytest-dev/pytest/issues/5975). This PR updates our sybil dependency so we no longer use the deprecated API; these updates were made in [1.4.0](https://github.com/cjw296/sybil/commit/b0d14610d2b3e324e5cc075c0fa2e6f396d6507d#diff-3f15a3a4e0eb38e9885b9aac89e026e1).

## How is this patch tested?
- [ ] Unit tests
- [x] Integration tests
- [x] Manual tests

Run `docs/test` after updating pytest.