### PR TITLE
[HLS-627] Improve lift_over_variants performance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -325,21 +325,21 @@ def crossReleaseStep(step: ReleaseStep): Seq[ReleaseStep] = {
 }
 
 releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
-    inquireVersions,
-    runClean
-  ) ++
-  crossReleaseStep(runTest) ++
-  Seq(
-    setReleaseVersion,
-    updateStableVersion,
-    commitReleaseVersion,
-    commitStableVersion,
-    tagRelease
-  ) ++
-  crossReleaseStep(publishArtifacts) ++
-  crossReleaseStep(releaseStepCommandAndRemaining("stagedRelease/test")) ++
-  Seq(
-    setNextVersion,
-    commitNextVersion
-  )
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean
+) ++
+crossReleaseStep(runTest) ++
+Seq(
+  setReleaseVersion,
+  updateStableVersion,
+  commitReleaseVersion,
+  commitStableVersion,
+  tagRelease
+) ++
+crossReleaseStep(publishArtifacts) ++
+crossReleaseStep(releaseStepCommandAndRemaining("stagedRelease/test")) ++
+Seq(
+  setNextVersion,
+  commitNextVersion
+)


### PR DESCRIPTION
Signed-off-by: kianfar77 <kiavash.kianfar@databricks.com>

## What changes are proposed in this pull request?

This PR removed the usage of htsjdk.samtools.reference.ReferenceSequence.getBaseString on long sequences and replaces it with getBases followed by converting only the desired part of the byte array to string.

Before this change, on a small cluster the transformer took close to 2 hours to do liftover on 1000 genome chr22 vcf due to a lot of string allocation and GC. After this change, the liftover takes about 10min. 

## How is this patch tested?
- [x] Unit tests
- [x] Integration tests
- [x] Manual tests

(Details)
