### PR TITLE
Use python functions instead of string expressions in docs

### DIFF
--- a/docs/source/etl/utility-functions.rst
+++ b/docs/source/etl/utility-functions.rst
@@ -23,7 +23,7 @@ whose parameter structs require a certain schema.
     row_one = Row(Row(str_col='foo', int_col=1, bool_col=True))
     row_two = Row(Row(str_col='bar', int_col=2, bool_col=False))
     base_df = spark.createDataFrame([row_one, row_two], schema=['base_col'])
-    subsetted_df = base_df.selectExpr("subset_struct(base_col, 'str_col', 'bool_col') as subsetted_col")
+    subsetted_df = base_df.select(glow.subset_struct('base_col', 'str_col', 'bool_col').alias('subsetted_col'))
 
 .. invisible-code-block: python
 
@@ -34,12 +34,13 @@ whose parameter structs require a certain schema.
 
 .. code-block:: python
 
-    added_df = base_df.selectExpr("add_struct_fields(base_col, 'float_col', 3.14, 'rev_str_col', reverse(base_col.str_col)) as added_col")
+    from pyspark.sql.functions import lit, reverse
+    added_df = base_df.select(glow.add_struct_fields('base_col', lit('float_col'), lit(3.14), lit('rev_str_col'), reverse(base_df.base_col.str_col)).alias('added_col'))
 
 .. invisible-code-block: python
 
    from decimal import Decimal
-   expected_added_col = Row(bool_col=True, int_col=1, str_col='foo', float_col=Decimal('3.14'), rev_str_col='oof')
+   expected_added_col = Row(bool_col=True, int_col=1, str_col='foo', float_col=3.14, rev_str_col='oof')
    assert_rows_equal(added_df.head().added_col, expected_added_col)
 
 
@@ -47,7 +48,7 @@ whose parameter structs require a certain schema.
 
 .. code-block:: python
 
-    expanded_df = base_df.selectExpr("expand_struct(base_col)")
+    expanded_df = base_df.select(glow.expand_struct('base_col'))
 
 .. invisible-code-block: python
 
@@ -65,7 +66,7 @@ libraries such as Spark's machine learning library (MLlib).
 .. code-block:: python
 
     array_df = spark.createDataFrame([Row([1.0, 2.0, 3.0]), Row([4.1, 5.1, 6.1])], schema=['array_col'])
-    dense_df = array_df.selectExpr('array_to_dense_vector(array_col) as dense_vector_col')
+    dense_df = array_df.select(glow.array_to_dense_vector('array_col').alias('dense_vector_col'))
 
 .. invisible-code-block: python
 
@@ -76,7 +77,7 @@ libraries such as Spark's machine learning library (MLlib).
 
 .. code-block:: python
 
-   sparse_df = array_df.selectExpr('array_to_sparse_vector(array_col) as sparse_vector_col')
+   sparse_df = array_df.select(glow.array_to_sparse_vector('array_col').alias('sparse_vector_col'))
 
 .. invisible-code-block: python
 
@@ -91,7 +92,7 @@ libraries such as Spark's machine learning library (MLlib).
     row_one = Row(vector_col=SparseVector(3, [0, 2], [1.0, 3.0]))
     row_two = Row(vector_col=SparseVector(3, [1], [1.0]))
     vector_df = spark.createDataFrame([row_one, row_two])
-    array_df = vector_df.selectExpr('vector_to_array(vector_col) as array_col')
+    array_df = vector_df.select(glow.vector_to_array('vector_col').alias('array_col'))
 
 .. invisible-code-block: python
 
@@ -104,7 +105,7 @@ libraries such as Spark's machine learning library (MLlib).
 
     from pyspark.ml.linalg import DenseMatrix
     matrix_df = spark.createDataFrame(Row([DenseMatrix(2, 3, range(6))]), schema=['matrix_col'])
-    array_df = matrix_df.selectExpr('explode_matrix(matrix_col) as array_col')
+    array_df = matrix_df.select(glow.explode_matrix('matrix_col').alias('array_col'))
 
 .. invisible-code-block: python
 
@@ -130,7 +131,7 @@ Glow supports numeric transformations on variant data for downstream calculation
     calls_schema = StructField('calls', ArrayType(IntegerType()))
     genotypes_schema = StructField('genotypes_col', ArrayType(StructType([calls_schema])))
     genotypes_df = spark.createDataFrame([missing_and_hom_ref, het_and_hom_alt], StructType([genotypes_schema]))
-    num_alt_alleles_df = genotypes_df.selectExpr('genotype_states(genotypes_col) as num_alt_alleles_col')
+    num_alt_alleles_df = genotypes_df.select(glow.genotype_states('genotypes_col').alias('num_alt_alleles_col'))
 
 .. invisible-code-block: python
 
@@ -146,7 +147,7 @@ Glow supports numeric transformations on variant data for downstream calculation
     unphased_above_threshold = Row(probabilities=[0.0, 0.0, 0.0, 1.0, 0.0, 0.0], num_alts=2, phased=False)
     phased_below_threshold = Row(probabilities=[0.1, 0.9, 0.8, 0.2], num_alts=1, phased=True)
     uncalled_df = spark.createDataFrame([unphased_above_threshold, phased_below_threshold])
-    hard_calls_df = uncalled_df.selectExpr('hard_calls(probabilities, num_alts, phased, 0.95) as calls')
+    hard_calls_df = uncalled_df.select(glow.hard_calls('probabilities', 'num_alts', 'phased', 0.95).alias('calls'))
 
 .. invisible-code-block: python
 
@@ -160,7 +161,7 @@ Glow supports numeric transformations on variant data for downstream calculation
 
     unsubstituted_row = Row(unsubstituted_values=[float('nan'), None, -1.0, 0.0, 1.0, 2.0, 3.0])
     unsubstituted_df = spark.createDataFrame([unsubstituted_row])
-    substituted_df = unsubstituted_df.selectExpr("mean_substitute(unsubstituted_values, -1.0) as substituted_values")
+    substituted_df = unsubstituted_df.select(glow.mean_substitute('unsubstituted_values', lit(-1.0)).alias('substituted_values'))
 
 .. invisible-code-block: python
 

--- a/docs/source/etl/variant-data.rst
+++ b/docs/source/etl/variant-data.rst
@@ -73,7 +73,11 @@ You can control the behavior of the VCF reader with a few parameters. All parame
    Starting from Glow 0.4.0, the ``splitToBiallelic`` option for the VCF reader no longer exists. To split multiallelic variants to biallelics use the :ref:`split_multiallelics<split_multiallelics>` transformer after loading the VCF.
 
 
-.. important:: The VCF reader uses the 0-start, half-open (zero-based) coordinate system.
+.. important:: The VCF reader uses the 0-start, half-open (zero-based) coordinate system. This means
+   that the ``start`` values in the DataFrame will be 1 lower than the values that appear in the VCF
+   file. For instance, if a variant has a POS value of 10 in a VCF file, the ``start`` column in the
+   DataFrame will contain the value 9. When writing to a VCF file, Glow converts positions back to a
+   1-based coordinate system as required by the VCF specification.
 
 You can save a DataFrame as a VCF file, which you can then read with other tools. To write a DataFrame as a single VCF file specify the format ``"bigvcf"``:
 

--- a/docs/source/etl/variant-normalization.rst
+++ b/docs/source/etl/variant-normalization.rst
@@ -87,9 +87,9 @@ The normalizer can also be used as a SQL expression function. See :ref:`Glow PyS
 
 .. code-block:: python
 
-  from pyspark.sql.functions import expr
-  normalization_expr = "normalize_variant(contigName, start, end, referenceAllele, alternateAlleles, '{ref_genome}')".format(ref_genome=ref_genome_path)
-  df_normalized = df_original.withColumn('normalizationResult', expr(normalization_expr))
+  from pyspark.sql.functions import lit
+  normalization_expr = glow.normalize_variant('contigName', 'start', 'end', 'referenceAllele', 'alternateAlleles', ref_genome_path)
+  df_normalized = df_original.withColumn('normalizationResult', normalization_expr)
 
 .. invisible-code-block: python
 


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
Some of our docs pages were written before we generated Python functions for our various expressions. Now that we have a more thorough Python API, we should use it in the documentation examples.

Also, I clarified the conversion to a 0-based coordinate system when ingesting VCF files.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

(Details)
