### PR TITLE
Spark Cross Release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -323,7 +323,7 @@ lazy val stagedRelease = (project in file("core/src/test"))
     unmanagedSourceDirectories in Test += baseDirectory.value / "shim" / majorMinorVersion(
       sparkVersion.value),
     libraryDependencies ++= testSparkDependencies.value ++ testCoreDependencies.value :+
-    "io.projectglow" %% s"glow_spark${majorVersion(sparkVersion.value)}_scala" % stableVersion.value % "test",
+    "io.projectglow" %% s"glow-spark${majorVersion(sparkVersion.value)}-scala" % stableVersion.value % "test",
     resolvers := Seq("bintray-staging" at "https://dl.bintray.com/projectglow/glow"),
     org
       .jetbrains

--- a/build.sbt
+++ b/build.sbt
@@ -378,8 +378,8 @@ crossReleaseStep(runTest, true) ++
 Seq(
   setReleaseVersion,
   updateStableVersion,
-//    commitReleaseVersion,
-//    commitStableVersion,
+  commitReleaseVersion,
+  commitStableVersion,
   tagRelease
 ) ++
 crossReleaseStep(publishArtifacts, false) ++

--- a/build.sbt
+++ b/build.sbt
@@ -354,7 +354,7 @@ def crossReleaseStep(step: ReleaseStep, requiresPySpark: Boolean): Seq[ReleaseSt
     if (requiresPySpark) "changePySparkVersion" else "")
 
   Seq(
-//    updateCondaEnvStep,
+    updateCondaEnvStep,
 //    releaseStepCommandAndRemaining(s"""set ThisBuild / sparkVersion := "$spark3""""),
 //    releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scala212""""),
 //    step,

--- a/build.sbt
+++ b/build.sbt
@@ -340,7 +340,7 @@ releaseCrossBuild := false
 
 lazy val changePySparkVersion = taskKey[Unit]("changePySparkVersion ")
 changePySparkVersion := {
-  s"conda remove -n glow pyspark ; conda install -n glow pyspark=$sparkOld" !
+  "conda remove -n glow pyspark" !; s"conda install -n glow pyspark=$sparkOld" !
 }
 
 lazy val updateCondaEnv = taskKey[Unit]("Update Glow Env To Latest Version")

--- a/build.sbt
+++ b/build.sbt
@@ -354,7 +354,7 @@ updateCondaEnv := {
 def crossReleaseStep(step: ReleaseStep, requiresPySpark: Boolean): Seq[ReleaseStep] = {
   val updateCondaEnvStep = releaseStepCommandAndRemaining(if (requiresPySpark) "updateCondaEnv" else "")
   val changePySparkVersionStep = releaseStepCommandAndRemaining(
-    if (requiresPySpark) s"changePySparkVersion($spark2)" else "")
+    if (requiresPySpark) s"""changePySparkVersion("$spark2")""" else "")
 
   Seq(
 //    updateCondaEnvStep,

--- a/build.sbt
+++ b/build.sbt
@@ -178,13 +178,13 @@ lazy val core = (project in file("core"))
     // Adds the Git hash to the MANIFEST file. We set it here instead of relying on sbt-release to
     // do so.
     packageOptions in (Compile, packageBin) +=
-      Package.ManifestAttributes("Git-Release-Hash" -> currentGitHash(baseDirectory.value)),
+    Package.ManifestAttributes("Git-Release-Hash" -> currentGitHash(baseDirectory.value)),
     bintrayRepository := "glow",
     libraryDependencies ++= coreDependencies.value :+ scalaLoggingDependency.value,
     Compile / unmanagedSourceDirectories +=
-      baseDirectory.value / "src" / "main" / "shim" / majorMinorVersion(sparkVersion.value),
+    baseDirectory.value / "src" / "main" / "shim" / majorMinorVersion(sparkVersion.value),
     Test / unmanagedSourceDirectories +=
-      baseDirectory.value / "src" / "test" / "shim" / majorMinorVersion(sparkVersion.value),
+    baseDirectory.value / "src" / "test" / "shim" / majorMinorVersion(sparkVersion.value),
     functionsTemplate := baseDirectory.value / "functions.scala.TEMPLATE",
     generatedFunctionsOutput := (Compile / scalaSource).value / "io" / "projectglow" / "functions.scala",
     sourceGenerators in Compile += generateFunctions
@@ -323,7 +323,7 @@ lazy val stagedRelease = (project in file("core/src/test"))
     unmanagedSourceDirectories in Test += baseDirectory.value / "shim" / majorMinorVersion(
       sparkVersion.value),
     libraryDependencies ++= testSparkDependencies.value ++ testCoreDependencies.value :+
-      "io.projectglow" %% s"glow_spark${majorVersion(sparkVersion.value)}_scala" % stableVersion.value % "test",
+    "io.projectglow" %% s"glow_spark${majorVersion(sparkVersion.value)}_scala" % stableVersion.value % "test",
     resolvers := Seq("bintray-staging" at "https://dl.bintray.com/projectglow/glow"),
     org
       .jetbrains
@@ -349,15 +349,16 @@ updateCondaEnv := {
 }
 
 def crossReleaseStep(step: ReleaseStep, requiresPySpark: Boolean): Seq[ReleaseStep] = {
-  val updateCondaEnvStep = releaseStepCommandAndRemaining(if (requiresPySpark) "updateCondaEnv" else "")
+  val updateCondaEnvStep = releaseStepCommandAndRemaining(
+    if (requiresPySpark) "updateCondaEnv" else "")
   val changePySparkVersionStep = releaseStepCommandAndRemaining(
     if (requiresPySpark) "changePySparkVersion" else "")
 
   Seq(
     updateCondaEnvStep,
-//    releaseStepCommandAndRemaining(s"""set ThisBuild / sparkVersion := "$spark3""""),
-//    releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scala212""""),
-//    step,
+    releaseStepCommandAndRemaining(s"""set ThisBuild / sparkVersion := "$sparkNew""""),
+    releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scalaNew""""),
+    step,
     changePySparkVersionStep,
     releaseStepCommandAndRemaining(s"""set ThisBuild / sparkVersion := "$sparkOld""""),
     releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scalaOld""""),
@@ -373,18 +374,17 @@ releaseProcess := Seq[ReleaseStep](
   inquireVersions,
   runClean
 ) ++
-  crossReleaseStep(runTest, true) ++
-  Seq(
-    setReleaseVersion,
-    updateStableVersion,
+crossReleaseStep(runTest, true) ++
+Seq(
+  setReleaseVersion,
+  updateStableVersion,
 //    commitReleaseVersion,
 //    commitStableVersion,
-    tagRelease
-  ) ++
-  crossReleaseStep(publishArtifacts, false) ++
-  crossReleaseStep(releaseStepCommandAndRemaining("stagedRelease/test"), false) ++
-  Seq(
-    setNextVersion,
-    commitNextVersion
-  )
-
+  tagRelease
+) ++
+crossReleaseStep(publishArtifacts, false) ++
+crossReleaseStep(releaseStepCommandAndRemaining("stagedRelease/test"), false) ++
+Seq(
+  setNextVersion,
+  commitNextVersion
+)

--- a/build.sbt
+++ b/build.sbt
@@ -7,14 +7,14 @@ import sbt.Keys._
 import sbt.librarymanagement.ModuleID
 import sbt.nio.Keys._
 
-lazy val scalaNew = "2.12.8"
-lazy val scalaOld = "2.11.12"
+lazy val scala212 = "2.12.8"
+lazy val scala211 = "2.11.12"
 
-lazy val sparkNew = "3.0.0"
-lazy val sparkOld = "2.4.5"
+lazy val spark3 = "3.0.0"
+lazy val spark2 = "2.4.5"
 
 lazy val sparkVersion = settingKey[String]("sparkVersion")
-ThisBuild / sparkVersion := sys.env.getOrElse("SPARK_VERSION", sparkNew)
+ThisBuild / sparkVersion := sys.env.getOrElse("SPARK_VERSION", spark3)
 
 def majorVersion(version: String): String = {
   StringUtils.ordinalIndexOf(version, ".", 1) match {
@@ -30,7 +30,7 @@ def majorMinorVersion(version: String): String = {
   }
 }
 
-ThisBuild / scalaVersion := sys.env.getOrElse("SCALA_VERSION", scalaNew)
+ThisBuild / scalaVersion := sys.env.getOrElse("SCALA_VERSION", scala212)
 ThisBuild / organization := "io.projectglow"
 ThisBuild / scalastyleConfig := baseDirectory.value / "scalastyle-config.xml"
 ThisBuild / publish / skip := true
@@ -161,11 +161,11 @@ lazy val root = (project in file(".")).aggregate(core, python, docs)
 lazy val scalaLoggingDependency = settingKey[ModuleID]("scalaLoggingDependency")
 ThisBuild / scalaLoggingDependency := {
   (ThisBuild / scalaVersion).value match {
-    case `scalaOld` => "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
-    case `scalaNew` => "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2"
+    case `scala211` => "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2"
+    case `scala212` => "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2"
     case _ =>
       throw new IllegalArgumentException(
-        "Only supported Scala versions are: " + Seq(scalaOld, scalaNew))
+        "Only supported Scala versions are: " + Seq(scala211, scala212))
   }
 }
 
@@ -173,7 +173,7 @@ lazy val core = (project in file("core"))
   .settings(
     commonSettings,
     functionGenerationSettings,
-    name := s"glow_spark${majorVersion(sparkVersion.value)}_scala",
+    name := s"glow-spark${majorVersion(sparkVersion.value)}-scala",
     publish / skip := false,
     // Adds the Git hash to the MANIFEST file. We set it here instead of relying on sbt-release to
     // do so.
@@ -340,7 +340,7 @@ releaseCrossBuild := false
 
 lazy val changePySparkVersion = taskKey[Unit]("changePySparkVersion ")
 changePySparkVersion := {
-  "conda remove -n glow pyspark" !; s"conda install -n glow pyspark=$sparkOld" !
+  "conda remove -n glow pyspark" !; s"conda install -n glow pyspark=$spark2" !
 }
 
 lazy val updateCondaEnv = taskKey[Unit]("Update Glow Env To Latest Version")
@@ -356,14 +356,14 @@ def crossReleaseStep(step: ReleaseStep, requiresPySpark: Boolean): Seq[ReleaseSt
 
   Seq(
     updateCondaEnvStep,
-    releaseStepCommandAndRemaining(s"""set ThisBuild / sparkVersion := "$sparkNew""""),
-    releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scalaNew""""),
+    releaseStepCommandAndRemaining(s"""set ThisBuild / sparkVersion := "$spark3""""),
+    releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scala212""""),
     step,
     changePySparkVersionStep,
-    releaseStepCommandAndRemaining(s"""set ThisBuild / sparkVersion := "$sparkOld""""),
-    releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scalaOld""""),
+    releaseStepCommandAndRemaining(s"""set ThisBuild / sparkVersion := "$spark2""""),
+    releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scala211""""),
     step,
-    releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scalaNew""""),
+    releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scala212""""),
     step,
     updateCondaEnvStep
   )

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ import sbt.nio.Keys._
 lazy val scalaNew = "2.12.8"
 lazy val scalaOld = "2.11.12"
 
-lazy val sparkOld = "2.4.5"
 lazy val sparkNew = "3.0.0"
+lazy val sparkOld = "2.4.5"
 
 lazy val sparkVersion = settingKey[String]("sparkVersion")
 ThisBuild / sparkVersion := sys.env.getOrElse("SPARK_VERSION", sparkNew)

--- a/build.sbt
+++ b/build.sbt
@@ -357,10 +357,10 @@ def crossReleaseStep(step: ReleaseStep, requiresPySpark: Boolean): Seq[ReleaseSt
     if (requiresPySpark) s"changePySparkVersion($spark2)" else "")
 
   Seq(
-    updateCondaEnvStep,
-    releaseStepCommandAndRemaining(s"""set ThisBuild / sparkVersion := "$spark3""""),
-    releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scala212""""),
-    step,
+//    updateCondaEnvStep,
+//    releaseStepCommandAndRemaining(s"""set ThisBuild / sparkVersion := "$spark3""""),
+//    releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scala212""""),
+//    step,
     changePySparkVersionStep,
     releaseStepCommandAndRemaining(s"""set ThisBuild / sparkVersion := "$spark2""""),
     releaseStepCommandAndRemaining(s"""set ThisBuild / scalaVersion := "$scala211""""),
@@ -380,8 +380,8 @@ releaseProcess := Seq[ReleaseStep](
   Seq(
     setReleaseVersion,
     updateStableVersion,
-    commitReleaseVersion,
-    commitStableVersion,
+//    commitReleaseVersion,
+//    commitStableVersion,
     tagRelease
   ) ++
   crossReleaseStep(publishArtifacts, false) ++

--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,7 @@ lazy val core = (project in file("core"))
   .settings(
     commonSettings,
     functionGenerationSettings,
-    name := s"glow-spark${majorVersion(sparkVersion.value)}-scala",
+    name := s"glow-spark${majorVersion(sparkVersion.value)}",
     publish / skip := false,
     // Adds the Git hash to the MANIFEST file. We set it here instead of relying on sbt-release to
     // do so.
@@ -323,7 +323,7 @@ lazy val stagedRelease = (project in file("core/src/test"))
     unmanagedSourceDirectories in Test += baseDirectory.value / "shim" / majorMinorVersion(
       sparkVersion.value),
     libraryDependencies ++= testSparkDependencies.value ++ testCoreDependencies.value :+
-    "io.projectglow" %% s"glow-spark${majorVersion(sparkVersion.value)}-scala" % stableVersion.value % "test",
+    "io.projectglow" %% s"glow-spark${majorVersion(sparkVersion.value)}" % stableVersion.value % "test",
     resolvers := Seq("bintray-staging" at "https://dl.bintray.com/projectglow/glow"),
     org
       .jetbrains

--- a/build.sbt
+++ b/build.sbt
@@ -340,7 +340,7 @@ releaseCrossBuild := false
 
 lazy val changePySparkVersion = taskKey[Unit]("changePySparkVersion ")
 changePySparkVersion := {
-  s";conda remove -n glow pyspark; conda install -n glow pyspark=$sparkOld" !
+  s"conda remove -n glow pyspark ; conda install -n glow pyspark=$sparkOld" !
 }
 
 lazy val updateCondaEnv = taskKey[Unit]("Update Glow Env To Latest Version")

--- a/downversion-pyspark.txt
+++ b/downversion-pyspark.txt
@@ -1,0 +1,2 @@
+conda remove -n glow pyspark
+conda install -n glow pyspark=2.4.5

--- a/downversion-pyspark.txt
+++ b/downversion-pyspark.txt
@@ -1,2 +1,0 @@
-conda remove -n glow pyspark
-conda install -n glow pyspark=2.4.5


### PR DESCRIPTION
Signed-off-by: kianfar77 <kiavash.kianfar@databricks.com>

## What changes are proposed in this pull request?
This PR modifies build.sbt to cross release glow for 
- Spark3 Scala 2.12 
- Spark2 Scala 2.12
- Spark2 Scala 2.11.

## How is this patch tested?
I ran a round of test release and all worked well. 


(Details)
