### PR TITLE
Fix BgenRowConverterSuite with AQE enabled

### DIFF
--- a/core/src/test/scala/io/projectglow/bgen/BgenRowConverterSuite.scala
+++ b/core/src/test/scala/io/projectglow/bgen/BgenRowConverterSuite.scala
@@ -74,7 +74,12 @@ class BgenRowConverterSuite extends BgenConverterBaseTest {
   }
 
   test("phased") {
-    compareVcfToBgen(spark, s"$testRoot/phased.16bits.bgen", s"$testRoot/phased.16bits.vcf", 16, true)
+    compareVcfToBgen(
+      spark,
+      s"$testRoot/phased.16bits.bgen",
+      s"$testRoot/phased.16bits.vcf",
+      16,
+      true)
   }
 
   test("works with adaptive query execution enabled") {


### PR DESCRIPTION
## What changes are proposed in this pull request?

We need to use `map(_.copy())` every time we use `queryExecution.toRdd`, as `InternalRow`s are re-used (see https://github.com/apache/spark/blob/76330e029540fa7ff4311c682135efd8bf0804e5/sql/core/src/main/scala/org/apache/spark/sql/execution/QueryExecution.scala#L121). Without this, our tests failed when adaptive query execution (AQE) was enabled. I fixed this bug in our tests and added a regression test.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests