### PR TITLE
Hint a merge join for logistic regression; don't warn if labels are b…

### DIFF
--- a/python/glow/wgr/linear_model/functions.py
+++ b/python/glow/wgr/linear_model/functions.py
@@ -549,7 +549,7 @@ def validate_inputs(labeldf: pd.DataFrame, covdf: pd.DataFrame, label_type='eith
     DataFrame must and no missing values and should be standardized to zero mean and unit standard
     deviation. The label DataFrame is validated according to the label typle. If 'continuous', the
     label DataFrame must contain no missing values and should be standardized to zero mean and unit
-    standard deviation. If 'binary', all values in the label DataFrame should be either 0, 1, or
+    standard deviation. If 'binary', all values in the label DataFrame should be 0, 1, or
     missing. If 'either', each column in the label DataFrame should conform to the validation rules
     for either 'continuous' or 'binary'.
 
@@ -570,7 +570,7 @@ def validate_inputs(labeldf: pd.DataFrame, covdf: pd.DataFrame, label_type='eith
     elif label_type == 'either':
         __check_binary_or_standardized(labeldf)
     else:
-        raise ValueError(f'label_type should be either "continuous", "binary", or "either". Found '
+        raise ValueError(f'label_type should be "continuous", "binary", or "either". Found '
                          f'{label_type}.')
 
 

--- a/python/glow/wgr/linear_model/functions.py
+++ b/python/glow/wgr/linear_model/functions.py
@@ -556,8 +556,8 @@ def __check_binary_or_standardized(df: pd.DataFrame) -> None:
 def validate_inputs(labeldf: pd.DataFrame, covdf: pd.DataFrame, label_type='either') -> None:
     """
     Performs basic input validation on the label and covariates pandas DataFrames. The covariates
-    DataFrame must and no missing values and should be standardized to zero mean and unit standard
-    deviation. The label DataFrame is validated according to the label typle. If 'continuous', the
+    DataFrame must have no missing values and should be standardized to zero mean and unit standard
+    deviation. The label DataFrame is validated according to the label type. If label_type is 'continuous', the
     label DataFrame must contain no missing values and should be standardized to zero mean and unit
     standard deviation. If 'binary', all values in the label DataFrame should be 0, 1, or
     missing. If 'either', each column in the label DataFrame should conform to the validation rules
@@ -695,6 +695,7 @@ def apply_model_df(blockdf, modeldf, cvdf, transform_udf, transform_key_pattern,
         join_type : Join type for join between blockdf and modeldf. 
     """
 
+    # Hint a sort-merge join to avoid an automatic broadcast join that may cause an OOM
     return blockdf.drop('header_block', 'sort_key') \
         .join(modeldf.drop('header_block').hint('merge'), ['sample_block', 'header'], join_type) \
         .withColumn('label', f.coalesce(f.col('label'), f.col('labels').getItem(0))) \

--- a/python/glow/wgr/linear_model/functions.py
+++ b/python/glow/wgr/linear_model/functions.py
@@ -527,14 +527,21 @@ def __check_binary_or_standardized(df: pd.DataFrame) -> None:
         mean = df[label].mean()
         std_dev = df[label].std()
         num_non_binary_values = __num_non_binary_values(df[label])
-        has_missing = any(df[label].isnull())
+        continuous_ok = math.isclose(mean, 0, abs_tol=0.01) and math.isclose(
+            std_dev, 1, abs_tol=0.01)
 
-        if not ((math.isclose(mean, 0, abs_tol=0.01) and math.isclose(std_dev, 1, abs_tol=0.01) and
-                 not has_missing) or num_non_binary_values == 0):
+        print('CHECKING COL ' + label)
+        if num_non_binary_values == 0:
+            # Valid binary trait
+            continue
+        elif df[label].isnull().any():
+            # Throw an error if there are missing values in a continuous phenotype
+            raise ValueError(f"Missing values are present in the label DataFrame's {label} column")
+        elif not continuous_ok:
+            print('CONTINUOUS OK ' + str(continuous_ok))
             warnings.warn(
-                f"Column {label} is neither standardized nor binary (mean={mean}, "
-                f"std_dev={std_dev}, has_missing={has_missing}, num_non_binary_values={num_non_binary_values})",
-                UserWarning)
+                f"Label {label} is neither standardized nor binary (mean={mean}, "
+                f"std_dev={std_dev}, num_non_binary_values={num_non_binary_values})", UserWarning)
 
 
 @typechecked

--- a/python/glow/wgr/linear_model/functions.py
+++ b/python/glow/wgr/linear_model/functions.py
@@ -466,7 +466,6 @@ def __assert_all_present(df: pd.DataFrame, col_name: str, df_name: str) -> None:
     Args:
         df : Pandas DataFrame
     """
-    print(f'Checking {col_name} in {df_name}')
     if df[col_name].isnull().any():
         raise ValueError(
             f"Missing values are present in the {df_name} dataframe's {col_name} column")
@@ -575,7 +574,6 @@ def validate_inputs(labeldf: pd.DataFrame, covdf: pd.DataFrame, label_type='eith
         __check_standardized(covdf, 'covariate')
     if label_type == 'continuous':
         for col in labeldf:
-            print(col)
             __assert_all_present(labeldf, col, 'label')
         __check_standardized(labeldf, 'label')
     elif label_type == 'binary':

--- a/python/glow/wgr/linear_model/logistic_model.py
+++ b/python/glow/wgr/linear_model/logistic_model.py
@@ -184,12 +184,8 @@ class LogisticRegression:
         else:
             raise ValueError(f'response must be either "linear" or "sigmoid", received "{response}"')
 
-        return blockdf.drop('header_block', 'sort_key') \
-            .join(modeldf.drop('header_block'), ['sample_block', 'header'], join_type) \
-            .withColumn('label', f.coalesce(f.col('label'), f.col('labels').getItem(0))) \
-            .groupBy(transform_key_pattern) \
-            .apply(transform_udf) \
-            .join(cvdf, ['label', 'alpha'], 'inner')
+        return apply_model_df(blockdf, modeldf, cvdf, transform_udf, transform_key_pattern,
+                              join_type)
 
     def transform(self,
                   blockdf: DataFrame,

--- a/python/glow/wgr/linear_model/ridge_model.py
+++ b/python/glow/wgr/linear_model/ridge_model.py
@@ -280,13 +280,8 @@ class RidgeRegression:
                                          self.alphas, covdf), reduced_matrix_struct,
             PandasUDFType.GROUPED_MAP)
 
-        # Hint a sort-merge join to avoid an automatic broadcast join that may cause an OOM
-        blocked_prediction_df = blockdf.drop('header_block', 'sort_key') \
-            .join(modeldf.drop('header_block').hint('merge'), ['sample_block', 'header'], 'right') \
-            .withColumn('label', f.coalesce(f.col('label'), f.col('labels').getItem(0))) \
-            .groupBy(transform_key_pattern) \
-            .apply(transform_udf) \
-            .join(cvdf, ['label', 'alpha'], 'inner')
+        blocked_prediction_df = apply_model_df(blockdf, modeldf, cvdf, transform_udf,
+                                               transform_key_pattern, 'right')
 
         pivoted_df = flatten_prediction_df(blocked_prediction_df, sample_blocks, labeldf)
 

--- a/python/glow/wgr/linear_model/tests/test_functions.py
+++ b/python/glow/wgr/linear_model/tests/test_functions.py
@@ -90,6 +90,16 @@ def test_labels_and_covars_ok(spark):
     covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -1, 1]})
     with pytest.warns(None) as record:
         validate_inputs(labeldf, covdf, 'continuous')
+
+        # Add a binary trait
+        labeldf['Trait_3'] = [0, 1, math.nan]
+        validate_inputs(labeldf, covdf, 'either')
+
+        # Delete continuous traits and check binary validation
+        del labeldf['Trait_1']
+        del labeldf['Trait_2']
+        validate_inputs(labeldf, covdf, 'binary')
+
     assert len(record) == 0
 
 

--- a/python/glow/wgr/linear_model/tests/test_functions.py
+++ b/python/glow/wgr/linear_model/tests/test_functions.py
@@ -84,12 +84,14 @@ def test_generate_alphas(spark):
     }
     assert generate_alphas(df) == expected_alphas
 
+
 def test_labels_and_covars_ok(spark):
     labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, -1]})
     covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -1, 1]})
     with pytest.warns(None) as record:
         validate_inputs(labeldf, covdf, 'continuous')
     assert len(record) == 0
+
 
 def test_assert_labels_all_present(spark):
     labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, math.nan]})

--- a/python/glow/wgr/linear_model/tests/test_functions.py
+++ b/python/glow/wgr/linear_model/tests/test_functions.py
@@ -103,46 +103,52 @@ def test_labels_and_covars_ok(spark):
     assert len(record) == 0
 
 
+def expect_validation_warning(labeldf, covdf, label_types):
+    for label_type in label_types:
+        with pytest.warns(UserWarning):
+            validate_inputs(labeldf, covdf, label_type)
+
+
+def expect_validation_error(labeldf, covdf, label_types):
+    for label_type in label_types:
+        with pytest.raises(ValueError):
+            validate_inputs(labeldf, covdf, label_type)
+
+
 def test_assert_labels_all_present(spark):
     labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, math.nan]})
     covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -1, 1]})
-    with pytest.raises(ValueError):
-        validate_inputs(labeldf, covdf, 'continuous')
+    expect_validation_error(labeldf, covdf, ['continuous'])
 
 
 def test_assert_covars_all_present(spark):
     labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, -1]})
     covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -1, math.nan]})
-    with pytest.raises(ValueError):
-        validate_inputs(labeldf, covdf)
+    expect_validation_error(labeldf, covdf, ['either', 'continuous', 'binary'])
 
 
 def test_check_labels_zero_mean(spark):
     labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, 3]})
     covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -1, 1]})
-    with pytest.warns(UserWarning):
-        validate_inputs(labeldf, covdf)
+    expect_validation_warning(labeldf, covdf, ['either', 'continuous'])
 
 
 def test_check_labels_unit_stddev(spark):
     labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 2, -2]})
     covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -1, 1]})
-    with pytest.warns(UserWarning):
-        validate_inputs(labeldf, covdf)
+    expect_validation_warning(labeldf, covdf, ['either', 'continuous'])
 
 
 def test_check_covars_zero_mean(spark):
     labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, -1]})
     covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, 3, 1]})
-    with pytest.warns(UserWarning):
-        validate_inputs(labeldf, covdf)
+    expect_validation_warning(labeldf, covdf, ['either', 'continuous'])
 
 
 def test_check_covars_unit_stddev(spark):
     labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, -1]})
     covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -2, 2]})
-    with pytest.warns(UserWarning):
-        validate_inputs(labeldf, covdf)
+    expect_validation_warning(labeldf, covdf, ['either', 'continuous'])
 
 
 def test_check_labels_binary_or_continuous(spark):

--- a/python/glow/wgr/linear_model/tests/test_functions.py
+++ b/python/glow/wgr/linear_model/tests/test_functions.py
@@ -86,45 +86,57 @@ def test_generate_alphas(spark):
 
 
 def test_assert_labels_all_present(spark):
-    labeldf = pd.DataFrame({'Trait_1': [-1, 1], 'Trait_2': [1, math.nan]})
-    covdf = pd.DataFrame({'Covariate_1': [1, -1], 'Covariate_2': [-1, 1]})
+    labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, math.nan]})
+    covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -1, 1]})
     with pytest.raises(ValueError):
-        validate_inputs(labeldf, covdf)
+        validate_inputs(labeldf, covdf, 'continuous')
 
 
 def test_assert_covars_all_present(spark):
-    labeldf = pd.DataFrame({'Trait_1': [-1, 1], 'Trait_2': [1, -1]})
-    covdf = pd.DataFrame({'Covariate_1': [1, -1], 'Covariate_2': [-1, math.nan]})
+    labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, -1]})
+    covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -1, math.nan]})
     with pytest.raises(ValueError):
         validate_inputs(labeldf, covdf)
 
 
 def test_check_labels_zero_mean(spark):
-    labeldf = pd.DataFrame({'Trait_1': [-1, 1], 'Trait_2': [1, 3]})
-    covdf = pd.DataFrame({'Covariate_1': [1, -1], 'Covariate_2': [-1, 1]})
+    labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, 3]})
+    covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -1, 1]})
     with pytest.warns(UserWarning):
         validate_inputs(labeldf, covdf)
 
 
 def test_check_labels_unit_stddev(spark):
-    labeldf = pd.DataFrame({'Trait_1': [-1, 1], 'Trait_2': [2, -2]})
-    covdf = pd.DataFrame({'Covariate_1': [1, -1], 'Covariate_2': [-1, 1]})
+    labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 2, -2]})
+    covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -1, 1]})
     with pytest.warns(UserWarning):
         validate_inputs(labeldf, covdf)
 
 
 def test_check_covars_zero_mean(spark):
-    labeldf = pd.DataFrame({'Trait_1': [-1, 1], 'Trait_2': [1, -1]})
-    covdf = pd.DataFrame({'Covariate_1': [1, -1], 'Covariate_2': [3, 1]})
+    labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, -1]})
+    covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, 3, 1]})
     with pytest.warns(UserWarning):
         validate_inputs(labeldf, covdf)
 
 
 def test_check_covars_unit_stddev(spark):
-    labeldf = pd.DataFrame({'Trait_1': [-1, 1], 'Trait_2': [1, -1]})
-    covdf = pd.DataFrame({'Covariate_1': [1, -1], 'Covariate_2': [-2, 2]})
+    labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, -1]})
+    covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -2, 2]})
     with pytest.warns(UserWarning):
         validate_inputs(labeldf, covdf)
+
+
+def test_check_labels_binary_or_continuous(spark):
+    labeldf = pd.DataFrame({'Trait_1': [0, 1, math.nan], 'Trait_2': [0, 1, -1]})
+    covdf = pd.DataFrame()
+    with pytest.warns(None) as record:
+        validate_inputs(labeldf, covdf, 'either')
+    assert len(record) == 0
+
+    labeldf['Trait_3'] = [0, 2, 3]
+    with pytest.warns(UserWarning):
+        validate_inputs(labeldf, covdf, 'either')
 
 
 def test_new_headers_one_level(spark):

--- a/python/glow/wgr/linear_model/tests/test_functions.py
+++ b/python/glow/wgr/linear_model/tests/test_functions.py
@@ -84,6 +84,12 @@ def test_generate_alphas(spark):
     }
     assert generate_alphas(df) == expected_alphas
 
+def test_labels_and_covars_ok(spark):
+    labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, -1]})
+    covdf = pd.DataFrame({'Covariate_1': [0, 1, -1], 'Covariate_2': [0, -1, 1]})
+    with pytest.warns(None) as record:
+        validate_inputs(labeldf, covdf, 'continuous')
+    assert len(record) == 0
 
 def test_assert_labels_all_present(spark):
     labeldf = pd.DataFrame({'Trait_1': [0, -1, 1], 'Trait_2': [0, 1, math.nan]})


### PR DESCRIPTION
…inary in RidgeReducer

Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
Fixes two small issues with WGR for binary traits:
- We would warn that the labels weren't standardized during the reduction step. It's expected that the labels are binary and thus not standardized for binary traits.
- We weren't hinting a merge join (instead of broadcast) during logistic regression. I put the logic into a function called by `RidgeRegression` and `LogisticRegression`.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

Manual test pending
