### PR TITLE
Re-initialize beta vector between genotypes in LogisticRegression

### DIFF
--- a/core/src/main/scala/io/projectglow/sql/expressions/FirthTest.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/FirthTest.scala
@@ -161,6 +161,7 @@ class FirthNewtonArgs(numRows: Int, numCols: Int) {
 
   def initFromNullFit(nullFit: FirthNewtonArgs): Unit = {
     b(0 until nullFit.b.length) := nullFit.b
+    b(nullFit.b.length to -1)
   }
 }
 

--- a/core/src/main/scala/io/projectglow/sql/expressions/FirthTest.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/FirthTest.scala
@@ -161,7 +161,7 @@ class FirthNewtonArgs(numRows: Int, numCols: Int) {
 
   def initFromNullFit(nullFit: FirthNewtonArgs): Unit = {
     b(0 until nullFit.b.length) := nullFit.b
-    b(nullFit.b.length to -1)
+    b(nullFit.b.length to -1) := 0d
   }
 }
 

--- a/core/src/main/scala/io/projectglow/sql/expressions/FirthTest.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/FirthTest.scala
@@ -161,7 +161,6 @@ class FirthNewtonArgs(numRows: Int, numCols: Int) {
 
   def initFromNullFit(nullFit: FirthNewtonArgs): Unit = {
     b(0 until nullFit.b.length) := nullFit.b
-    b(nullFit.b.length to -1) := 0d
   }
 }
 

--- a/core/src/main/scala/io/projectglow/sql/expressions/LogisticRegressionGwas.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/LogisticRegressionGwas.scala
@@ -170,6 +170,7 @@ class NewtonIterationsState(numRows: Int, numCols: Int) {
     val X1 = X(::, r1)
 
     b(r0) := nullFitArgs.b
+    b(r1) := 0d
     val eta = offsetOption match {
       case Some(offset) => offset + X * b
       case None => X * b

--- a/core/src/test/scala/io/projectglow/tertiary/LogisticRegressionSuite.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/LogisticRegressionSuite.scala
@@ -518,4 +518,18 @@ class LogisticRegressionSuite extends GlowBaseTest {
       LogisticRegressionGwas.logitTests.get("FIRTH"))
     assert(LogisticRegressionGwas.logitTests.get("monkey").isEmpty)
   }
+
+  // Fix bug where a row that exhibits separation pollutes the cached state
+  test("some rows separate") {
+    val testData = TestData(
+      Array(Array(1, 1, 0, 0), Array(1, 0, 1, 0)),
+      Array(1, 1, 0, 0),
+      Array(Array(1), Array(1), Array(1), Array(1)),
+      None
+    )
+    val result = runLRT(testData, onSpark = false)
+    checkAllNan(result.head)
+    assert(
+      result(1) == LogitTestResults(0.0, 1.0, List(0.01984252396814992, 50.39681451841221), 1.0))
+  }
 }

--- a/core/src/test/scala/io/projectglow/tertiary/NewtonIterationsStateSuite.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/NewtonIterationsStateSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectglow.tertiary
 
 import breeze.linalg.{DenseMatrix, DenseVector}

--- a/core/src/test/scala/io/projectglow/tertiary/NewtonIterationsStateSuite.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/NewtonIterationsStateSuite.scala
@@ -1,0 +1,23 @@
+package io.projectglow.tertiary
+
+import breeze.linalg.{DenseMatrix, DenseVector}
+import io.projectglow.sql.GlowBaseTest
+import io.projectglow.sql.expressions.NewtonIterationsState
+
+class NewtonIterationsStateSuite extends GlowBaseTest {
+  test("initializes beta correctly") {
+    val rows = 10
+    val cols = 11
+    val fitState = new NewtonIterationsState(rows, cols)
+    val X = DenseMatrix.ones[Double](rows, cols)
+    val Y = DenseVector.ones[Double](rows)
+    val nullFit = new NewtonIterationsState(rows, cols - 1)
+    nullFit.b := 1d
+    fitState.b := 2d
+    fitState.initFromMatrixAndNullFit(X, Y, None, nullFit)
+
+    assert(fitState.b(0 to -2) == DenseVector.ones[Double](cols - 1))
+    // the last element in beta should be set to 0 in initialization
+    assert(fitState.b(-1) == 0d)
+  }
+}

--- a/functions.yml
+++ b/functions.yml
@@ -465,11 +465,11 @@ gwas_functions:
           >>> df.select(glow.expand_struct(glow.logistic_regression_gwas('genotypes', 'phenotypes', 'covariates', 'Firth'))).collect()
           [Row(beta=0.7418937644793101, oddsRatio=2.09990848346903, waldConfidenceInterval=[0.2509874689201784, 17.569066925598555], pValue=0.3952193664793294)]
           >>> df.select(glow.expand_struct(glow.logistic_regression_gwas('genotypes', 'phenotypes', 'covariates', 'LRT'))).collect()
-          [Row(beta=1.1658962684583645, oddsRatio=3.208797540870915, waldConfidenceInterval=[0.2970960052553798, 34.65674891673014], pValue=0.2943946848756771)]
+          [Row(beta=1.1658962684583645, oddsRatio=3.208797538802116, waldConfidenceInterval=[0.29709600522888285, 34.65674887513274], pValue=0.2943946848756769)]
           >>> df.select(glow.expand_struct(glow.logistic_regression_gwas('genotypes', 'phenotypes', 'covariates', 'Firth', 'offset'))).collect()
           [Row(beta=0.8024832156793392, oddsRatio=2.231074294047771, waldConfidenceInterval=[0.2540891981649045, 19.590334974925725], pValue=0.3754070658316332)]
           >>> df.select(glow.expand_struct(glow.logistic_regression_gwas('genotypes', 'phenotypes', 'covariates', 'LRT', 'offset'))).collect()
-          [Row(beta=1.1996041727573317, oddsRatio=3.3188029903029874, waldConfidenceInterval=[0.30711890785889034, 35.86380716587069], pValue=0.28571379886741566)]
+          [Row(beta=1.1996041727573317, oddsRatio=3.3188029900720117, waldConfidenceInterval=[0.3071189078535928, 35.863807161497334], pValue=0.2857137988674153)]
       args:
         - name: genotypes
           doc: An numeric array of genotypes

--- a/python/glow/functions.py
+++ b/python/glow/functions.py
@@ -592,11 +592,11 @@ def logistic_regression_gwas(genotypes: Union[Column, str], phenotypes: Union[Co
         >>> df.select(glow.expand_struct(glow.logistic_regression_gwas('genotypes', 'phenotypes', 'covariates', 'Firth'))).collect()
         [Row(beta=0.7418937644793101, oddsRatio=2.09990848346903, waldConfidenceInterval=[0.2509874689201784, 17.569066925598555], pValue=0.3952193664793294)]
         >>> df.select(glow.expand_struct(glow.logistic_regression_gwas('genotypes', 'phenotypes', 'covariates', 'LRT'))).collect()
-        [Row(beta=1.1658962684583645, oddsRatio=3.208797540870915, waldConfidenceInterval=[0.2970960052553798, 34.65674891673014], pValue=0.2943946848756771)]
+        [Row(beta=1.1658962684583645, oddsRatio=3.208797538802116, waldConfidenceInterval=[0.29709600522888285, 34.65674887513274], pValue=0.2943946848756769)]
         >>> df.select(glow.expand_struct(glow.logistic_regression_gwas('genotypes', 'phenotypes', 'covariates', 'Firth', 'offset'))).collect()
         [Row(beta=0.8024832156793392, oddsRatio=2.231074294047771, waldConfidenceInterval=[0.2540891981649045, 19.590334974925725], pValue=0.3754070658316332)]
         >>> df.select(glow.expand_struct(glow.logistic_regression_gwas('genotypes', 'phenotypes', 'covariates', 'LRT', 'offset'))).collect()
-        [Row(beta=1.1996041727573317, oddsRatio=3.3188029903029874, waldConfidenceInterval=[0.30711890785889034, 35.86380716587069], pValue=0.28571379886741566)]
+        [Row(beta=1.1996041727573317, oddsRatio=3.3188029900720117, waldConfidenceInterval=[0.3071189078535928, 35.863807161497334], pValue=0.2857137988674153)]
 
     Args:
         genotypes : An numeric array of genotypes


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
Previously we were not re-initializing the `beta` vector between genotypes for a given phenotype. This means that if one row results in a `NaN` beta, all successive rows will fail to converge.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

(Details)
