### PR TITLE
Disable gatk docs link checks

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -234,5 +234,7 @@ linkcheck_ignore = [
     r'https://academic.oup.com*',
     # Certificate verification failure
     r'https://www.ensembl.org*',
-    r'http://www.sequenceontology.org*'
+    r'http://www.sequenceontology.org*',
+    # Captcha required
+    r'https://gatk.broadinstitute.org*',
 ]


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
These pages are now gated by a captcha. It's unfortunate that our link checker doesn't work here since the GATK links are pretty important, but I don't think there's a way around.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
