### PR TITLE
Document BGEN/PLINK allele order

### DIFF
--- a/docs/source/etl/variant-data.rst
+++ b/docs/source/etl/variant-data.rst
@@ -182,6 +182,11 @@ The schema of the resulting DataFrame matches that of the VCF reader.
 | ``hardCallThreshold`` | double  | 0.9          | Sets the threshold for hard calls.                                                                         |
 +-----------------------+---------+--------------+------------------------------------------------------------------------------------------------------------+
 
+.. important::
+
+    The BGEN reader and writer assume that the first allele is the reference allele, and that all following alleles are
+    alternate alleles.
+
 You can use the ``DataFrameWriter`` API to save a single BGEN file, which you can then read with other tools.
 
 .. invisible-code-block: python
@@ -250,5 +255,9 @@ files must be located at ``{prefix}.bim`` and ``{prefix}.fam``.
 | ``mergeFidIid``      | boolean | ``true``        | If true, sets the sample ID to the family ID and individual ID merged with an underscore delimiter. |
 |                      |         |                 | If false, sets the sample ID to the individual ID.                                                  |
 +----------------------+---------+-----------------+-----------------------------------------------------------------------------------------------------+
+
+.. important::
+
+    The PLINK reader sets the first allele as the alternate allele, and the second allele as an alternate allele.
 
 .. notebook:: .. etl/variant-data.html

--- a/docs/source/etl/variant-data.rst
+++ b/docs/source/etl/variant-data.rst
@@ -184,8 +184,8 @@ The schema of the resulting DataFrame matches that of the VCF reader.
 
 .. important::
 
-    The BGEN reader and writer assume that the first allele is the reference allele, and that all following alleles are
-    alternate alleles.
+    The BGEN reader and writer assume that the first allele in the ``.bgen`` file is the reference
+    allele, and that all following alleles are alternate alleles.
 
 You can use the ``DataFrameWriter`` API to save a single BGEN file, which you can then read with other tools.
 
@@ -258,6 +258,7 @@ files must be located at ``{prefix}.bim`` and ``{prefix}.fam``.
 
 .. important::
 
-    The PLINK reader sets the first allele as the alternate allele, and the second allele as an alternate allele.
+    The PLINK reader sets the first allele in the ``.bed`` file as the alternate allele, and the
+    second allele as an alternate allele.
 
 .. notebook:: .. etl/variant-data.html


### PR DESCRIPTION
## What changes are proposed in this pull request?

Our BGEN reader and writer assume that the first allele is the reference, and that following alleles are alternate alleles. Our PLINK reader assumes that the first allele is the alternate, and that the second allele is an alternate allele. This PR adds clarifying documentation.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

Ran `make livehtml` to ensure the tip showed up.
