### PR TITLE
Update Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Glow is an open-source toolkit to enable bioinformatics at biobank-scale and bey
 [![Documentation
 Status](https://readthedocs.org/projects/glow/badge/?version=latest)](https://glow.readthedocs.io/en/latest/?badge=latest)
 [![PyPi](https://img.shields.io/pypi/v/glow.py.svg)](https://pypi.org/project/glow.py/)
-[![Maven Central](https://img.shields.io/maven-central/v/io.projectglow/glow_2.11.svg)](https://mvnrepository.com/artifact/io.projectglow)
+[![Maven Central](https://img.shields.io/maven-central/v/io.projectglow/glow-spark3_2.12.svg)](https://mvnrepository.com/artifact/io.projectglow)
 [![Coverage Status](https://codecov.io/gh/projectglow/glow/branch/master/graph/badge.svg)](https://codecov.io/gh/projectglow/glow)
 [![DOI](https://zenodo.org/badge/212904926.svg)](https://zenodo.org/badge/latestdoi/212904926)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates our out-of-date Maven Central badge (currently stuck on v0.5.0), as we started releasing separate Spark 2 and 3 artifacts.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual tests

Visited shield link manually and verified it reflected v0.6.0.