### PR TITLE
Ignore covariates in binary WGR transform for linear response

### DIFF
--- a/python/glow/wgr/linear_model/logistic_model.py
+++ b/python/glow/wgr/linear_model/logistic_model.py
@@ -19,6 +19,7 @@ from pyspark.sql.functions import pandas_udf, PandasUDFType
 import pyspark.sql.functions as f
 from typeguard import typechecked
 from typing import Any, Dict, List
+import warnings
 from glow.logging import record_hls_event
 
 
@@ -164,7 +165,7 @@ class LogisticRegression:
 
         if response == 'linear':
             if not covdf.empty:
-                warn('Ignoring covariates for linear response')
+                warnings.warn('Ignoring covariates for linear response')
                 covdf = pd.DataFrame({})
             transform_udf = pandas_udf(
                 lambda key, pdf: apply_model(key, transform_key_pattern, pdf, labeldf,

--- a/python/glow/wgr/linear_model/logistic_model.py
+++ b/python/glow/wgr/linear_model/logistic_model.py
@@ -163,6 +163,9 @@ class LogisticRegression:
         transform_key_pattern = ['sample_block', 'label']
 
         if response == 'linear':
+            if not covdf.empty:
+                print('Ignoring covariates for linear response')
+                covdf = pd.DataFrame({})
             transform_udf = pandas_udf(
                 lambda key, pdf: apply_model(key, transform_key_pattern, pdf, labeldf,
                                              sample_blocks, self.alphas, covdf),
@@ -295,8 +298,4 @@ class LogisticRegression:
             rows are indexed by sample ID and the columns by label. The column types are float64.
         """
         modeldf, cvdf = self.fit(blockdf, labeldf, sample_blocks, covdf)
-        if response == 'linear':
-            return self.transform(blockdf, labeldf, sample_blocks, modeldf, cvdf, pd.DataFrame({}),
-                                  response)
-        else:
-            return self.transform(blockdf, labeldf, sample_blocks, modeldf, cvdf, covdf, response)
+        return self.transform(blockdf, labeldf, sample_blocks, modeldf, cvdf, covdf, response)

--- a/python/glow/wgr/linear_model/logistic_model.py
+++ b/python/glow/wgr/linear_model/logistic_model.py
@@ -153,7 +153,7 @@ class LogisticRegression:
             validation routine.
             covdf : Pandas DataFrame containing covariates to be included in every model in the stacking
                 ensemble.  The covariates should not include an explicit intercept term, as one will be
-                added automatically.
+                added automatically. Covariates will be ignored for a linear response.
             response : String specifying what transformation to apply ("linear" or "sigmoid")
 
         Returns:
@@ -164,7 +164,7 @@ class LogisticRegression:
 
         if response == 'linear':
             if not covdf.empty:
-                print('Ignoring covariates for linear response')
+                warn('Ignoring covariates for linear response')
                 covdf = pd.DataFrame({})
             transform_udf = pandas_udf(
                 lambda key, pdf: apply_model(key, transform_key_pattern, pdf, labeldf,
@@ -211,7 +211,7 @@ class LogisticRegression:
             validation routine.
             covdf : Pandas DataFrame containing covariates to be included in every model in the stacking
                 ensemble (optional). The covariates should not include an explicit intercept term, as one will be
-                added automatically.
+                added automatically. Covariates will be ignored for a linear response.
             response : String specifying the desired output.  Can be 'linear' to specify the direct output of the linear
                 WGR model (default) or 'sigmoid' to specify predicted label probabilities.
 
@@ -250,7 +250,7 @@ class LogisticRegression:
             validation routine.
             covdf : covdf : Pandas DataFrame containing covariates to be included in every model in the stacking
                 ensemble (optional). The covariates should not include an explicit intercept term, as one will be
-                added automatically.
+                added automatically. Covariates will be ignored for a linear response.
             response : String specifying the desired output.  Can be 'linear' to specify the direct output of the linear
                 WGR model (default) or 'sigmoid' to specify predicted label probabilities.
             chromosomes : List of chromosomes for which to generate a prediction (optional). If not provided, the
@@ -289,7 +289,7 @@ class LogisticRegression:
             sample_blocks : Dict containing a mapping of sample_block ID to a list of corresponding sample IDs
             covdf : Pandas DataFrame containing covariates to be included in every model in the stacking
                 ensemble (optional). The covariates should not include an explicit intercept term, as one will be
-                added automatically.
+                added automatically. Covariates will be ignored during the transformation step for a linear response.
             response : String specifying the desired output.  Can be 'linear' to specify the direct output of the linear
                 WGR model (default) or 'sigmoid' to specify predicted label probabilities.
 

--- a/python/glow/wgr/linear_model/tests/test_logistic_regression.py
+++ b/python/glow/wgr/linear_model/tests/test_logistic_regression.py
@@ -269,7 +269,7 @@ def test_logistic_regression_transform(spark):
 
     logreg = LogisticRegression(alpha_values)
     modeldf, cvdf = logreg.fit(lvl1df, labeldf, sample_blocks, covdf)
-    wgr_cov_df = logreg.transform(lvl1df, labeldf, sample_blocks, modeldf, cvdf)
+    wgr_cov_df = logreg.transform(lvl1df, labeldf, sample_blocks, modeldf, cvdf, covdf)
     wgr_cov_glow = wgr_cov_df[test_label].to_numpy()
 
     assert (np.allclose(np.array(test_values['wgr_cov']), wgr_cov_glow))


### PR DESCRIPTION
## What changes are proposed in this pull request?

Changes how we handle covariates passed into binary GloWGR's transform function. Rather than handling it as a special case in `transform_loco`, pushes the replacement of the covariate matrix down to the transform function.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests