### PR TITLE
Address edge case with tabix offsets and partitioned files

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/TabixIndexHelper.scala
+++ b/core/src/main/scala/io/projectglow/vcf/TabixIndexHelper.scala
@@ -489,10 +489,10 @@ object TabixIndexHelper extends GlowLogging {
               }
             val blockRangeStart = Math.max(file.start, minOverBlocks >> 16) // Shift 16 bits to get
             // file offset of the bin from bgzipped virtual file offset.
-            val blockRangeEnd = Math.min(file.start + file.length, (maxOverBlocks >> 16) + 0xFFFF)
+            val blockRangeEnd = Math.min(file.start + file.length, maxOverBlocks >> 16)
             // 0xFFFF is the maximum possible length of an uncompressed bin.
             if (blockRangeStart <= blockRangeEnd) {
-              Some((blockRangeStart, blockRangeEnd))
+              Some((blockRangeStart, Math.min(file.start + file.length, blockRangeEnd + 0xFFFF)))
             } else {
               None
             }

--- a/core/src/main/scala/io/projectglow/vcf/TabixIndexHelper.scala
+++ b/core/src/main/scala/io/projectglow/vcf/TabixIndexHelper.scala
@@ -514,6 +514,7 @@ object TabixIndexHelper extends GlowLogging {
             val blockRangeStart = Math.max(file.start, minOverBlocks)
             val blockRangeEnd = Math.min(file.start + file.length, maxOverBlocks)
             if (blockRangeStart <= blockRangeEnd && fileContainsBlockStart) {
+              // 0xFFFF is the maximum possible length of an uncompressed bin
               Some((blockRangeStart, Math.min(file.start + file.length, blockRangeEnd + 0xFFFF)))
             } else {
               None

--- a/core/src/main/scala/io/projectglow/vcf/TabixIndexHelper.scala
+++ b/core/src/main/scala/io/projectglow/vcf/TabixIndexHelper.scala
@@ -422,6 +422,21 @@ object TabixIndexHelper extends GlowLogging {
    * If a check fails generates appropriate message
    * Otherwise generates block range by querying tabix index based
    * on the filteredSimpleInterval produces by makeFilteredInterval.
+   *
+   * Returns a block range if the partitioned file contains the start position of a gzip
+   * block that overlaps the filtered interval (based on the tabix index). The block
+   * range excludes any part of the file before the start of the first desired block,
+   * or after the end of the last desired block.
+   *
+   * No block range will be returned if:
+   * - The partitioned file does not include any of the desired blocks' start positions
+   * - The partitioned file ends before the start of the first desired block
+   * - The partitioned file starts after the start of the last desired block
+   *
+   * This is designed based on the following invariants:
+   * - Spark's files are partitioned arbitrarily
+   * - The bgzip codec requires that a block starts within the partitioned file
+   * - The bgzip codec reads an entire block, whether or not it fits within the partition
    */
   def getFileRangeToRead(
       hadoopFs: FileSystem,
@@ -482,19 +497,19 @@ object TabixIndexHelper extends GlowLogging {
           if (offsetList.isEmpty) {
             None
           } else {
-            // Do not return any files without a BGZIP header
+            // Flag used to avoid returning any files without a BGZIP header
             var fileContainsBlockStart = false
             // Shift 16 bits to get file offset of the bin from bgzipped virtual file offset.
-            val (firstStart, firstLast) =
+            val (firstStart, firstEnd) =
               (offsetList(0).getStartPosition >> 16, offsetList(0).getEndPosition >> 16)
-            val (minOverBlocks, maxOverBlocks) = offsetList.foldLeft((firstStart, firstLast)) {
+            val (minOverBlocks, maxOverBlocks) = offsetList.foldLeft((firstStart, firstEnd)) {
               case ((aStart, aEnd), o) =>
                 val bStart = o.getStartPosition >> 16
                 val bEnd = o.getEndPosition >> 16
                 if (!fileContainsBlockStart) {
                   fileContainsBlockStart = (file.start <= bStart) && (file.start + file.length >= bStart)
                 }
-                (Math.min(aStart, bStart), Math.max(aEnd, bStart))
+                (Math.min(aStart, bStart), Math.max(aEnd, bEnd))
             }
             val blockRangeStart = Math.max(file.start, minOverBlocks)
             val blockRangeEnd = Math.min(file.start + file.length, maxOverBlocks)

--- a/core/src/main/scala/io/projectglow/vcf/TabixIndexHelper.scala
+++ b/core/src/main/scala/io/projectglow/vcf/TabixIndexHelper.scala
@@ -485,7 +485,7 @@ object TabixIndexHelper extends GlowLogging {
             // Do not return any files without a BGZIP header
             var fileContainsBlockStart = false
             // Shift 16 bits to get file offset of the bin from bgzipped virtual file offset.
-            val firstStart, firstLast =
+            val (firstStart, firstLast) =
               (offsetList(0).getStartPosition >> 16, offsetList(0).getEndPosition >> 16)
             val (minOverBlocks, maxOverBlocks) = offsetList.foldLeft((firstStart, firstLast)) {
               case ((aStart, aEnd), o) =>

--- a/core/src/test/scala/io/projectglow/vcf/TabixHelperSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/TabixHelperSuite.scala
@@ -810,37 +810,43 @@ class TabixHelperSuite extends GlowBaseTest with GlowLogging {
         .isEmpty)
   }
 
-  test("Do not read partitioned file starting after offset end") {
+  test("Overlapping partitions and tabix offsets") {
     val path = new Path(testMultiBlockVcf)
     val conf = sparkContext.hadoopConfiguration
     val fs = path.getFileSystem(conf)
     val interval = Some(SimpleInterval("20", 10132301, 10214079))
     // Tabix offsets for this interval is (1005005266,1005032301) -> (15335,15335)
 
+    // Partition before offset start
     val p1 = PartitionedFile(InternalRow.empty, testMultiBlockVcf, 0, 15334)
     val r1 = TabixIndexHelper.getFileRangeToRead(fs, p1, conf, true, true, interval)
     assert(r1.isEmpty)
 
+    // Partition overlapping with offset
     val p2 = PartitionedFile(InternalRow.empty, testMultiBlockVcf, 15330, 1000)
     val r2 = TabixIndexHelper.getFileRangeToRead(fs, p2, conf, true, true, interval)
     assert(r2 == Some(15335, 16330))
 
+    // Partition starts within 0xFFFF of offset
     val p3 = PartitionedFile(InternalRow.empty, testMultiBlockVcf, 15340, 1000)
     val r3 = TabixIndexHelper.getFileRangeToRead(fs, p3, conf, true, true, interval)
     assert(r3.isEmpty)
 
+    // Partition after offset
     val p4 = PartitionedFile(InternalRow.empty, testMultiBlockVcf, 20000, 1000)
     val r4 = TabixIndexHelper.getFileRangeToRead(fs, p4, conf, true, true, interval)
     assert(r4.isEmpty)
 
+    // Do not exceed file start/end
     val p5 = PartitionedFile(InternalRow.empty, testMultiBlockVcf, 15330, 65635)
     val r5 = TabixIndexHelper.getFileRangeToRead(fs, p5, conf, true, true, interval)
     assert(r5 == Some(15335, 15335 + 0xFFFF))
   }
 
   test("Small partitions") {
-    spark.conf.set("spark.sql.files.maxPartitionBytes", "100")
-    val rows = spark.read.format(sourceName).load(testMultiBlockVcf).filter(
+    val sess = spark.newSession()
+    sess.conf.set("spark.sql.files.maxPartitionBytes", "100")
+    val rows = sess.read.format(sourceName).load(testMultiBlockVcf).filter(
       "contigName = '20' and start > 10012714 and end < 10014990"
     )
     assert(rows.count() == 3)

--- a/core/src/test/scala/io/projectglow/vcf/TabixHelperSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/TabixHelperSuite.scala
@@ -846,9 +846,8 @@ class TabixHelperSuite extends GlowBaseTest with GlowLogging {
   test("Small partitions") {
     val sess = spark.newSession()
     sess.conf.set("spark.sql.files.maxPartitionBytes", "100")
-    val rows = sess.read.format(sourceName).load(testMultiBlockVcf).filter(
-      "contigName = '20' and start > 10012714 and end < 10014990"
-    )
+    val rows = sess.read.format(sourceName).load(testMultiBlockVcf)
+      .filter("contigName = '20' and start > 10012714 and end < 10014990")
     assert(rows.count() == 3)
   }
 }

--- a/core/src/test/scala/io/projectglow/vcf/TabixHelperSuite.scala
+++ b/core/src/test/scala/io/projectglow/vcf/TabixHelperSuite.scala
@@ -846,7 +846,10 @@ class TabixHelperSuite extends GlowBaseTest with GlowLogging {
   test("Small partitions") {
     val sess = spark.newSession()
     sess.conf.set("spark.sql.files.maxPartitionBytes", "100")
-    val rows = sess.read.format(sourceName).load(testMultiBlockVcf)
+    val rows = sess
+      .read
+      .format(sourceName)
+      .load(testMultiBlockVcf)
       .filter("contigName = '20' and start > 10012714 and end < 10014990")
     assert(rows.count() == 3)
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes the logic for parsing whether a partition file overlaps with the tabix offsets. In particular, does not include a partitioned file as overlapping if it does not include the start position of the last tabix offset (even if it's within 0xFFFF), as it only contains the tail of the block and will trigger a failure when trying to read the GZIP block header.

During this exploration, we also learned that the BGZF codec seeks to the first BGZF header and reads through to the end of any block it has already started, whether or not it is within the limits of the partitioned file: https://github.com/apache/hadoop/blob/d4c8d4d4d203c934e8074b31289a28724c0842cf/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-core/src/main/java/org/apache/hadoop/mapreduce/lib/input/CompressedSplitLineReader.java#L46.

However, if there is no header in the partitioned file, the codec explodes. This PR adds an extra check that the partitioned file contains any of the desired block start positions; if not, they are not returned.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

Manual testing has verified that this resolves the edge case.