### PR TITLE
Parallelize null model fit for logistic regression

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -22,7 +22,8 @@ def _spark_builder():
     return SparkSession.builder \
         .master("local[2]") \
         .config("spark.hadoop.io.compression.codecs", "io.projectglow.sql.util.BGZFCodec") \
-        .config("spark.ui.enabled", "false")
+        .config("spark.ui.enabled", "false") \
+        .config("spark.sql.execution.arrow.pyspark.enabled", "true")
 
 # sbt guarantees that this environment variable is set for python tests
 SPARK_VERSION = os.environ['SPARK_VERSION']

--- a/python/glow/gwas/functions.py
+++ b/python/glow/gwas/functions.py
@@ -78,6 +78,10 @@ def _have_same_elements(idx1: pd.Index, idx2: pd.Index) -> bool:
     return idx1.sort_values().equals(idx2.sort_values())
 
 
+def _get_contigs_from_offset_df(offset_df: pd.DataFrame) -> pd.Series:
+    return offset_df.index.get_level_values(1).unique()
+
+
 T = TypeVar('T')
 
 
@@ -95,8 +99,8 @@ def _loco_dispatch(genotype_pdf: pd.DataFrame, state: Union[T, Dict[str, T]], f:
 
 class _OffsetType(Enum):
     NO_OFFSET = 0
-    SINGLE_OFFSET = 1
-    LOCO_OFFSET = 2
+    SINGLE_OFFSET = 1  # Per-sample offset for all contigs
+    LOCO_OFFSET = 2  # Per-sample, per-contig offset
 
 
 @typechecked

--- a/python/glow/gwas/functions.py
+++ b/python/glow/gwas/functions.py
@@ -78,7 +78,7 @@ def _have_same_elements(idx1: pd.Index, idx2: pd.Index) -> bool:
     return idx1.sort_values().equals(idx2.sort_values())
 
 
-def _get_contigs_from_offset_df(offset_df: pd.DataFrame) -> pd.Series:
+def _get_contigs_from_loco_df(offset_df: pd.DataFrame) -> pd.Series:
     return offset_df.index.get_level_values(1).unique()
 
 
@@ -116,7 +116,7 @@ def _validate_offset(phenotype_df: pd.DataFrame, offset_df: pd.DataFrame) -> _Of
                 raise ValueError(f'phenotype_df and offset_df should have the same index.')
             return _OffsetType.SINGLE_OFFSET
         elif offset_df.index.nlevels == 2:  # Indexed by sample id and contig
-            all_contigs = offset_df.index.get_level_values(1).unique()
+            all_contigs = _get_contigs_from_loco_df(offset_df)
             for contig in all_contigs:
                 offset_for_contig = offset_df.xs(contig, level=1)
                 if not _have_same_elements(phenotype_df.index, offset_for_contig.index):

--- a/python/glow/gwas/functions.py
+++ b/python/glow/gwas/functions.py
@@ -13,12 +13,6 @@ _VALUES_COLUMN_NAME = '_glow_regression_values'
 _GENOTYPES_COLUMN_NAME = 'genotypes'
 
 
-class _OffsetType(Enum):
-    NO_OFFSET = 0
-    SINGLE_OFFSET = 1
-    LOCO_OFFSET = 2
-
-
 def _check_spark_version(spark: SparkSession) -> bool:
     if int(spark.version.split('.')[0]) < 3:
         raise AttributeError(
@@ -99,8 +93,17 @@ def _loco_dispatch(genotype_pdf: pd.DataFrame, state: Union[T, Dict[str, T]], f:
         return f(genotype_pdf, state, *args)
 
 
+class _OffsetType(Enum):
+    NO_OFFSET = 0
+    SINGLE_OFFSET = 1
+    LOCO_OFFSET = 2
+
+
 @typechecked
 def _validate_offset(phenotype_df: pd.DataFrame, offset_df: pd.DataFrame) -> _OffsetType:
+    '''
+    Validates that the offset df matches the phenotype df. Returns the type of offset.
+    '''
     if not offset_df.empty:
         if not _have_same_elements(phenotype_df.columns, offset_df.columns):
             raise ValueError(f'phenotype_df and offset_df should have the same column names.')

--- a/python/glow/gwas/lin_reg.py
+++ b/python/glow/gwas/lin_reg.py
@@ -151,7 +151,7 @@ def _create_one_YState(Y: NDArray[(Any, Any), Float], phenotype_df: pd.DataFrame
                        offset_df: pd.DataFrame, Y_mask: NDArray[(Any, Any), Float], dt) -> YState:
     if not offset_df.empty:
         Y = (pd.DataFrame(Y, phenotype_df.index, phenotype_df.columns) - offset_df).to_numpy(dt)
-    Y = np.nan_to_num(Y) * Y_mask
+    Y *= Y_mask
     return YState(Y, np.sum(Y * Y, axis=0))
 
 

--- a/python/glow/gwas/lin_reg.py
+++ b/python/glow/gwas/lin_reg.py
@@ -141,7 +141,7 @@ def _create_YState(Y: NDArray[(Any, Any),
     if offset_type != gwas_fx._OffsetType.LOCO_OFFSET:
         return _create_one_YState(Y, phenotype_df, offset_df, Y_mask, dt)
 
-    all_contigs = gwas_fx._get_contigs_from_offset_df(offset_df)
+    all_contigs = gwas_fx._get_contigs_from_loco_df(offset_df)
     return {
         contig: _create_one_YState(Y, phenotype_df, offset_df.xs(contig, level=1), Y_mask, dt)
         for contig in all_contigs

--- a/python/glow/gwas/lin_reg.py
+++ b/python/glow/gwas/lin_reg.py
@@ -134,13 +134,14 @@ class YState:
     YdotY: NDArray[(Any), Float]
 
 
-def _create_YState(Y: NDArray[(Any, Any), Float], phenotype_df: pd.DataFrame,
-                   offset_df: pd.DataFrame, Y_mask: NDArray[(Any, Any), Float], dt):
+def _create_YState(Y: NDArray[(Any, Any),
+                              Float], phenotype_df: pd.DataFrame, offset_df: pd.DataFrame,
+                   Y_mask: NDArray[(Any, Any), Float], dt) -> Union[YState, Dict[str, YState]]:
     offset_type = gwas_fx._validate_offset(phenotype_df, offset_df)
     if offset_type != gwas_fx._OffsetType.LOCO_OFFSET:
         return _create_one_YState(Y, phenotype_df, offset_df, Y_mask, dt)
 
-    all_contigs = offset_df.index.get_level_values(1).unique()
+    all_contigs = gwas_fx._get_contigs_from_offset_df(offset_df)
     return {
         contig: _create_one_YState(Y, phenotype_df, offset_df.xs(contig, level=1), Y_mask, dt)
         for contig in all_contigs

--- a/python/glow/gwas/log_reg.py
+++ b/python/glow/gwas/log_reg.py
@@ -108,9 +108,9 @@ def logistic_regression(
 
 @dataclass
 class LogRegState:
-    inv_CtGammaC: NDArray[(Any, Any, Any), Float]
-    gamma: NDArray[(Any, Any), Float]
-    Y_res: NDArray[(Any, Any), Float]
+    inv_CtGammaC: NDArray[(Any, Any, Any), Float]  # n_phenotypes x n_covariates x n_covariates
+    gamma: NDArray[(Any, Any), Float]  # n_samples x n_phenotypes
+    Y_res: NDArray[(Any, Any), Float]  # n_samples x n_phenotypes
 
 
 def _logistic_null_model_predictions(y, X, mask, offset):

--- a/python/glow/gwas/tests/test_lin_reg.py
+++ b/python/glow/gwas/tests/test_lin_reg.py
@@ -19,7 +19,7 @@ def run_linear_regression(genotype_df, phenotype_df, covariate_df, fit_intercept
     Y[~Y_mask] = 0
     Q = np.linalg.qr(C)[0]
     Y = lr._residualize_in_place(Y, Q)
-    Y_state = lr._create_YState(Y, phenotype_df, None, Y_mask, np.float64)
+    Y_state = lr._create_YState(Y, phenotype_df, pd.DataFrame({}), Y_mask, np.float64)
     dof = C.shape[0] - C.shape[1] - 1
     pdf = pd.DataFrame({lr._VALUES_COLUMN_NAME: list(genotype_df.to_numpy('float64').T)})
 

--- a/python/glow/gwas/tests/test_log_reg.py
+++ b/python/glow/gwas/tests/test_log_reg.py
@@ -15,9 +15,9 @@ def run_score_test(genotype_df, phenotype_df, covariate_df, fit_intercept=True):
     Y[~Y_mask] = 0
     state_rows = [
         lr._prepare_one_phenotype(C, pd.Series({
-            'label': c,
-            'values': phenotype_df[c]
-        })) for c in phenotype_df
+            'label': p,
+            'values': phenotype_df[p]
+        })) for p in phenotype_df
     ]
     phenotype_names = phenotype_df.columns.to_series().astype('str')
     state = lr._pdf_to_log_reg_state(pd.DataFrame(state_rows), phenotype_names, C.shape[1])

--- a/python/glow/gwas/tests/test_log_reg.py
+++ b/python/glow/gwas/tests/test_log_reg.py
@@ -14,13 +14,13 @@ def run_score_test(genotype_df, phenotype_df, covariate_df, fit_intercept=True):
     Y_mask = ~np.isnan(Y)
     Y[~Y_mask] = 0
     state_rows = [
-        lr._create_one_log_reg_state(C, pd.Series({
+        lr._prepare_one_phenotype(C, pd.Series({
             'label': c,
             'values': phenotype_df[c]
         })) for c in phenotype_df
     ]
     phenotype_names = phenotype_df.columns.to_series().astype('str')
-    state = lr._create_log_reg_state_from_pdf(pd.DataFrame(state_rows), phenotype_names, C.shape[1])
+    state = lr._pdf_to_log_reg_state(pd.DataFrame(state_rows), phenotype_names, C.shape[1])
     values_df = pd.DataFrame({gwas_fx._VALUES_COLUMN_NAME: list(genotype_df.to_numpy().T)})
     return lr._logistic_regression_inner(values_df, state, C, Y_mask, lr.fallback_none,
                                          phenotype_df.columns.to_series().astype('str'))

--- a/python/glow/gwas/tests/test_log_reg.py
+++ b/python/glow/gwas/tests/test_log_reg.py
@@ -13,7 +13,14 @@ def run_score_test(genotype_df, phenotype_df, covariate_df, fit_intercept=True):
     Y = phenotype_df.to_numpy(copy=True)
     Y_mask = ~np.isnan(Y)
     Y[~Y_mask] = 0
-    state = lr._create_log_reg_state(Y, pd.DataFrame(), None, C, Y_mask)
+    state_rows = [
+        lr._create_one_log_reg_state(C, pd.Series({
+            'label': c,
+            'values': phenotype_df[c]
+        })) for c in phenotype_df
+    ]
+    phenotype_names = phenotype_df.columns.to_series().astype('str')
+    state = lr._create_log_reg_state_from_pdf(pd.DataFrame(state_rows), phenotype_names, C.shape[1])
     values_df = pd.DataFrame({gwas_fx._VALUES_COLUMN_NAME: list(genotype_df.to_numpy().T)})
     return lr._logistic_regression_inner(values_df, state, C, Y_mask, lr.fallback_none,
                                          phenotype_df.columns.to_series().astype('str'))

--- a/python/glow/wgr/functions.py
+++ b/python/glow/wgr/functions.py
@@ -184,7 +184,9 @@ def reshape_for_gwas(spark: SparkSession, label_df: pd.DataFrame) -> DataFrame:
             return transposed
 
         contigs = label_df.index.get_level_values(1).unique()
-        transposed_df = pd.concat([transpose_one(contig) for contig in contigs], keys=contigs, names=['contig', 'label'])
+        transposed_df = pd.concat([transpose_one(contig) for contig in contigs],
+                                  keys=contigs,
+                                  names=['contig', 'label'])
         column_names = ['contigName', 'label', 'values']
     else:
         raise ValueError('label_df must be indexed by sample id or by (sample id, contig name)')

--- a/python/glow/wgr/functions.py
+++ b/python/glow/wgr/functions.py
@@ -191,7 +191,7 @@ def reshape_for_gwas(spark: SparkSession, label_df: pd.DataFrame) -> DataFrame:
     else:
         raise ValueError('label_df must be indexed by sample id or by (sample id, contig name)')
 
-    # Can only create create a Spark DataFrame from pandas with ndarray columns in Spark 3+
+    # Can only create a Spark DataFrame from pandas with ndarray columns in Spark 3+
     if int(spark.version.split('.')[0]) < 3:
         values = transposed_df.to_numpy().tolist()
     else:

--- a/python/glow/wgr/functions.py
+++ b/python/glow/wgr/functions.py
@@ -153,7 +153,7 @@ def reshape_for_gwas(spark: SparkSession, label_df: pd.DataFrame) -> DataFrame:
         ...     index=pd.MultiIndex.from_tuples([('sample1', 'chr1'), ('sample1', 'chr2')]))
         >>> reshaped = reshape_for_gwas(spark, loco_label_df)
         >>> reshaped.head()
-        Row(label='label1', contigName='chr1', values=[1])
+        Row(contigName='chr1', label='label1', values=[1])
 
     Requires that:
 

--- a/python/glow/wgr/functions.py
+++ b/python/glow/wgr/functions.py
@@ -191,5 +191,10 @@ def reshape_for_gwas(spark: SparkSession, label_df: pd.DataFrame) -> DataFrame:
     else:
         raise ValueError('label_df must be indexed by sample id or by (sample id, contig name)')
 
-    transposed_df['values_array'] = list(transposed_df.to_numpy())
+    # Can only create create a Spark DataFrame from pandas with ndarray columns in Spark 3+
+    if int(spark.version.split('.')[0]) < 3:
+        values = transposed_df.to_numpy().tolist()
+    else:
+        values = list(transposed_df.to_numpy())
+    transposed_df['values_array'] = values
     return spark.createDataFrame(transposed_df[['values_array']].reset_index(), column_names)

--- a/python/glow/wgr/functions.py
+++ b/python/glow/wgr/functions.py
@@ -18,6 +18,7 @@ from pyspark import SparkContext
 from pyspark.sql import DataFrame, Row, SparkSession, SQLContext
 from typeguard import check_argument_types, check_return_type
 from typing import Dict, List
+from ..gwas.functions import _get_contigs_from_loco_df
 
 __all__ = ['get_sample_ids', 'block_variants_and_samples', 'reshape_for_gwas']
 
@@ -183,7 +184,7 @@ def reshape_for_gwas(spark: SparkSession, label_df: pd.DataFrame) -> DataFrame:
             transposed = label_df.xs(contig, level=1).T
             return transposed
 
-        contigs = label_df.index.get_level_values(1).unique()
+        contigs = _get_contigs_from_loco_df(label_df)
         transposed_df = pd.concat([transpose_one(contig) for contig in contigs],
                                   keys=contigs,
                                   names=['contig', 'label'])

--- a/python/glow/wgr/tests/test_pivot_for_gwas.py
+++ b/python/glow/wgr/tests/test_pivot_for_gwas.py
@@ -19,7 +19,7 @@ def test_pivot_loco(spark):
         ['sample_id', 'contigName'])
     pivoted = functions.reshape_for_gwas(spark, df)
     assert pivoted.count() == 12
-    assert pivoted.columns == ['label', 'contigName', 'values']
+    assert pivoted.columns == ['contigName', 'label', 'values']
     pt_list = pivoted.where('label = "sim100" and contigName = 1').head().values
     expected = df.xs(1, level='contigName')['sim100'].to_numpy()
     assert np.allclose(expected, np.array(pt_list))
@@ -32,7 +32,7 @@ def test_pivot_loco_string_contig(spark):
                      }).set_index(['sample_id', 'contigName'])
     pivoted = functions.reshape_for_gwas(spark, df)
     assert pivoted.count() == 12
-    assert pivoted.columns == ['label', 'contigName', 'values']
+    assert pivoted.columns == ['contigName', 'label', 'values']
     pt_list = pivoted.where('label = "sim100" and contigName = "1"').head().values
     expected = df.xs('1', level='contigName')['sim100'].to_numpy()
     assert np.allclose(expected, np.array(pt_list))

--- a/python/glow/wgr/tests/test_reshape_for_gwas.py
+++ b/python/glow/wgr/tests/test_reshape_for_gwas.py
@@ -1,48 +1,44 @@
 import numpy as np
 import pandas as pd
 import pytest
-from pyspark.sql import Row
-from pyspark.sql.functions import *
-from pyspark.sql.utils import AnalysisException
 import glow
-from glow.wgr import functions
 
 
 def test_error_too_many_levels(spark):
     df = pd.DataFrame(columns=['c1', 'c2', 'c3']).set_index(['c1', 'c2', 'c3'])
     with pytest.raises(ValueError):
-        functions.reshape_for_gwas(spark, df)
+        glow.wgr.reshape_for_gwas(spark, df)
 
 
-def test_pivot_loco(spark):
+def test_reshape_loco(spark):
     df = pd.read_csv('test-data/wgr/ridge-regression/level1YHatLoco.csv').set_index(
         ['sample_id', 'contigName'])
-    pivoted = functions.reshape_for_gwas(spark, df)
-    assert pivoted.count() == 12
-    assert pivoted.columns == ['contigName', 'label', 'values']
-    pt_list = pivoted.where('label = "sim100" and contigName = 1').head().values
+    reshaped = glow.wgr.reshape_for_gwas(spark, df)
+    assert reshaped.count() == 12
+    assert reshaped.columns == ['contigName', 'label', 'values']
+    pt_list = reshaped.where('label = "sim100" and contigName = 1').head().values
     expected = df.xs(1, level='contigName')['sim100'].to_numpy()
     assert np.allclose(expected, np.array(pt_list))
 
 
-def test_pivot_loco_string_contig(spark):
+def test_reshape_loco_string_contig(spark):
     df = pd.read_csv('test-data/wgr/ridge-regression/level1YHatLoco.csv',
                      dtype={
                          'contigName': 'str'
                      }).set_index(['sample_id', 'contigName'])
-    pivoted = functions.reshape_for_gwas(spark, df)
-    assert pivoted.count() == 12
-    assert pivoted.columns == ['contigName', 'label', 'values']
-    pt_list = pivoted.where('label = "sim100" and contigName = "1"').head().values
+    reshaped = glow.wgr.reshape_for_gwas(spark, df)
+    assert reshaped.count() == 12
+    assert reshaped.columns == ['contigName', 'label', 'values']
+    pt_list = reshaped.where('label = "sim100" and contigName = "1"').head().values
     expected = df.xs('1', level='contigName')['sim100'].to_numpy()
     assert np.allclose(expected, np.array(pt_list))
 
 
-def test_pivot_no_loco(spark):
+def test_reshape_no_loco(spark):
     df = pd.read_csv('test-data/wgr/ridge-regression/pts.csv').set_index('sample_id')
-    pivoted = functions.reshape_for_gwas(spark, df)
-    assert pivoted.count() == 4
-    assert pivoted.columns == ['label', 'values']
-    pt_list = pivoted.where('label = "sim100"').head().values
+    reshaped = glow.wgr.reshape_for_gwas(spark, df)
+    assert reshaped.count() == 4
+    assert reshaped.columns == ['label', 'values']
+    pt_list = reshaped.where('label = "sim100"').head().values
     expected = df['sim100']
     assert np.allclose(expected, pt_list)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fitting all the null models and preparing the broadcast data could take a looooong time with many phenotypes and loco offsets. Let's use Spark!

I also sped up the `reshape_for_gwas` function.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
