### PR TITLE
Regression function fixes / improvements

### DIFF
--- a/python/glow/gwas/approx_firth.py
+++ b/python/glow/gwas/approx_firth.py
@@ -36,14 +36,14 @@ class Model:
 
 
 @typechecked
-def _calculate_log_likelihood(beta: NDArray[(Any, ), Float], model: Any) -> LogLikelihood:
+def _calculate_log_likelihood(beta: NDArray[(Any, ), Float], model: Model) -> LogLikelihood:
 
-    pi = scipy.special.expit(model.exog @ beta + model.offset)
+    pi = scipy.special.expit(model.X @ beta + model.offset)
     p = pi * (1 - pi)
-    I = model.exog.T @ (p[:, None] * model.exog)
+    I = model.X.T @ (p[:, None] * model.X)
     _, log_abs_det = np.linalg.slogdet(I)
-    unpenalized_log_likelihood = np.sum(model.endog * np.log(pi) +
-                                        (1 - model.endog) * np.log(1 - pi))
+    unpenalized_log_likelihood = np.sum(model.y * np.log(pi) +
+                                        (1 - model.y) * np.log(1 - pi))
 
     penalty = 0.5 * log_abs_det
     deviance = -2 * (unpenalized_log_likelihood + penalty)

--- a/python/glow/gwas/approx_firth.py
+++ b/python/glow/gwas/approx_firth.py
@@ -42,8 +42,7 @@ def _calculate_log_likelihood(beta: NDArray[(Any, ), Float], model: Model) -> Lo
     p = pi * (1 - pi)
     I = model.X.T @ (p[:, None] * model.X)
     _, log_abs_det = np.linalg.slogdet(I)
-    unpenalized_log_likelihood = np.sum(model.y * np.log(pi) +
-                                        (1 - model.y) * np.log(1 - pi))
+    unpenalized_log_likelihood = np.sum(model.y * np.log(pi) + (1 - model.y) * np.log(1 - pi))
 
     penalty = 0.5 * log_abs_det
     deviance = -2 * (unpenalized_log_likelihood + penalty)

--- a/python/glow/gwas/approx_firth.py
+++ b/python/glow/gwas/approx_firth.py
@@ -24,7 +24,7 @@ class FirthFit:
 class FirthStatistics:
     effect: Float
     stderror: Float
-    tvalue: Float
+    chisq: Float
     pvalue: Float
 
 
@@ -202,4 +202,4 @@ def correct_approx_firth(x: NDArray[(Any, ), Float], y: NDArray[(Any, ), Float],
     pvalue = stats.chi2.sf(tvalue, 1)
     # Based on the Hessian of the unpenalized log-likelihood
     stderror = np.sqrt(np.linalg.pinv(firth_fit.log_likelihood.I).diagonal()[-1])
-    return FirthStatistics(effect=effect, stderror=stderror, tvalue=tvalue, pvalue=pvalue)
+    return FirthStatistics(effect=effect, stderror=stderror, chisq=tvalue, pvalue=pvalue)

--- a/python/glow/gwas/approx_firth.py
+++ b/python/glow/gwas/approx_firth.py
@@ -198,8 +198,8 @@ def correct_approx_firth(x: NDArray[(Any, ), Float], y: NDArray[(Any, ), Float],
     # Likelihood-ratio test
     null_model = Model(masked_X, masked_y, masked_offset)
     null_deviance = _calculate_log_likelihood(beta_init, null_model).deviance
-    tvalue = null_deviance - firth_fit.log_likelihood.deviance
-    pvalue = stats.chi2.sf(tvalue, 1)
+    chisq = null_deviance - firth_fit.log_likelihood.deviance
+    pvalue = stats.chi2.sf(chisq, 1)
     # Based on the Hessian of the unpenalized log-likelihood
     stderror = np.sqrt(np.linalg.pinv(firth_fit.log_likelihood.I).diagonal()[-1])
-    return FirthStatistics(effect=effect, stderror=stderror, chisq=tvalue, pvalue=pvalue)
+    return FirthStatistics(effect=effect, stderror=stderror, chisq=chisq, pvalue=pvalue)

--- a/python/glow/gwas/functions.py
+++ b/python/glow/gwas/functions.py
@@ -1,6 +1,6 @@
 from pyspark.sql import SparkSession, functions as fx
 from pyspark.sql.types import StructField, StructType, FloatType, DoubleType, ArrayType
-from typing import Any, Callable, Dict, List, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 import numpy as np
 import pandas as pd
 from nptyping import Float, NDArray

--- a/python/glow/gwas/lin_reg.py
+++ b/python/glow/gwas/lin_reg.py
@@ -134,9 +134,9 @@ class YState:
     YdotY: NDArray[(Any), Float]
 
 
-def _create_YState(Y: NDArray[(Any, Any),
-                              Float], phenotype_df: pd.DataFrame, offset_df: pd.DataFrame,
-                   Y_mask: NDArray[(Any, Any), Float], dt, contigs: Optional[List[str]]) -> Union[YState, Dict[str, YState]]:
+def _create_YState(Y: NDArray[(Any, Any), Float], phenotype_df: pd.DataFrame,
+                   offset_df: pd.DataFrame, Y_mask: NDArray[(Any, Any), Float], dt,
+                   contigs: Optional[List[str]]) -> Union[YState, Dict[str, YState]]:
 
     offset_type = gwas_fx._validate_offset(phenotype_df, offset_df)
     if offset_type != gwas_fx._OffsetType.LOCO_OFFSET:

--- a/python/glow/gwas/lin_reg.py
+++ b/python/glow/gwas/lin_reg.py
@@ -67,6 +67,10 @@ def linear_regression(genotype_df: DataFrame,
                     If two levels, the level 0 index should be the same as the ``phenotype_df``, and the level 1 index
                     should be the contig name. The two level index scheme allows for per-contig offsets like
                     LOCO predictions from GloWGR.
+        contigs : When using LOCO offsets, this parameter indicates the contigs that are currently under
+                  analysis. You can use this parameter to limit the size of the broadcasted data, which may
+                  be necessary with large sample sizes. If this parameter is omitted, it is inferred from
+                  the ``offset_df``.
         fit_intercept : Whether or not to add an intercept column to the covariate DataFrame
         values_column : A column name or column expression to test with linear regression. If a column name is provided,
                         ``genotype_df`` should have a column with this name and a numeric array type. If a column expression

--- a/python/glow/gwas/lin_reg.py
+++ b/python/glow/gwas/lin_reg.py
@@ -67,9 +67,8 @@ def linear_regression(genotype_df: DataFrame,
                     If two levels, the level 0 index should be the same as the ``phenotype_df``, and the level 1 index
                     should be the contig name. The two level index scheme allows for per-contig offsets like
                     LOCO predictions from GloWGR.
-        contigs : When using LOCO offsets, this parameter indicates the contigs that are currently under
-                  analysis. You can use this parameter to limit the size of the broadcasted data, which may
-                  be necessary with large sample sizes. If this parameter is omitted, it is inferred from
+        contigs : When using LOCO offsets, this parameter indicates the contigs to analyze. You can use this parameter to limit the size of the broadcasted data, which may
+                  be necessary with large sample sizes. If this parameter is omitted, the contigs are inferred from
                   the ``offset_df``.
         fit_intercept : Whether or not to add an intercept column to the covariate DataFrame
         values_column : A column name or column expression to test with linear regression. If a column name is provided,

--- a/python/glow/gwas/log_reg.py
+++ b/python/glow/gwas/log_reg.py
@@ -62,9 +62,8 @@ def logistic_regression(genotype_df: DataFrame,
         correction : Which test to use for variants that meet a significance threshold for the score test. Supported
                      methods are ``none`` and ``approx-firth``.
         pvalue_threshold : Variants with a pvalue below this threshold will be tested using the ``correction`` method.
-        contigs : When using LOCO offsets, this parameter indicates the contigs that are currently under
-                  analysis. You can use this parameter to limit the size of the broadcasted data, which may
-                  be necessary with large sample sizes. If this parameter is omitted, it is inferred from
+        contigs : When using LOCO offsets, this parameter indicates the contigs to analyze. You can use this parameter to limit the size of the broadcasted data, which may
+                  be necessary with large sample sizes. If this parameter is omitted, the contigs are inferred from
                   the ``offset_df``.
         fit_intercept : Whether or not to add an intercept column to the covariate DataFrame
         values_column : A column name or column expression to test with linear regression. If a column name is provided,
@@ -216,9 +215,9 @@ def _create_log_reg_state(
     Fitting the null logistic models can be expensive, so the work is distributed across the cluster
     using Pandas UDFs.
     '''
-    if contigs is not None:
-        offset_df = offset_df.loc[pd.IndexSlice[:, contigs], :]
     offset_type = gwas_fx._validate_offset(phenotype_df, offset_df)
+    if offset_type == gwas_fx._OffsetType.LOCO_OFFSET and contigs is not None:
+        offset_df = offset_df.loc[pd.IndexSlice[:, contigs], :]
     pivoted_phenotype_df = reshape_for_gwas(spark, phenotype_df)
     result_fields = [
         StructField('label', StringType()),

--- a/python/glow/gwas/log_reg.py
+++ b/python/glow/gwas/log_reg.py
@@ -202,9 +202,10 @@ def _pdf_to_log_reg_state(pdf: pd.DataFrame, phenotypes: pd.Series, n_covar: int
 
 
 @typechecked
-def _create_log_reg_state(spark: SparkSession, phenotype_df: pd.DataFrame, offset_df: pd.DataFrame,
-                          sql_type: DataType, C: NDArray[(Any, Any), Float], correction: str,
-                          fit_intercept: bool, contigs: Optional[List[str]]) -> Union[LogRegState, Dict[str, LogRegState]]:
+def _create_log_reg_state(
+        spark: SparkSession, phenotype_df: pd.DataFrame, offset_df: pd.DataFrame,
+        sql_type: DataType, C: NDArray[(Any, Any), Float], correction: str, fit_intercept: bool,
+        contigs: Optional[List[str]]) -> Union[LogRegState, Dict[str, LogRegState]]:
     '''
     Creates the broadcasted LogRegState object (or one object per contig if LOCO offsets were provided).
 
@@ -213,7 +214,6 @@ def _create_log_reg_state(spark: SparkSession, phenotype_df: pd.DataFrame, offse
     '''
     if contigs is not None:
         offset_df = offset_df.loc[pd.IndexSlice[:, contigs], :]
-    print(offset_df)
     offset_type = gwas_fx._validate_offset(phenotype_df, offset_df)
     pivoted_phenotype_df = reshape_for_gwas(spark, phenotype_df)
     result_fields = [

--- a/python/glow/gwas/log_reg.py
+++ b/python/glow/gwas/log_reg.py
@@ -81,7 +81,7 @@ def logistic_regression(genotype_df: DataFrame,
                                     True if succeeded, False if failed, null if correction was not applied.
         - ``chisq``: The chi squared test statistic according to the score test or the correction method
         - ``pvalue``: P value estimated from the test statistic
-        - ``phenotype``: The phenotype name as determiend by the column names of ``phenotype_df``
+        - ``phenotype``: The phenotype name as determined by the column names of ``phenotype_df``
     '''
 
     spark = genotype_df.sql_ctx.sparkSession

--- a/python/glow/gwas/log_reg.py
+++ b/python/glow/gwas/log_reg.py
@@ -62,6 +62,10 @@ def logistic_regression(genotype_df: DataFrame,
         correction : Which test to use for variants that meet a significance threshold for the score test. Supported
                      methods are ``none`` and ``approx-firth``.
         pvalue_threshold : Variants with a pvalue below this threshold will be tested using the ``correction`` method.
+        contigs : When using LOCO offsets, this parameter indicates the contigs that are currently under
+                  analysis. You can use this parameter to limit the size of the broadcasted data, which may
+                  be necessary with large sample sizes. If this parameter is omitted, it is inferred from
+                  the ``offset_df``.
         fit_intercept : Whether or not to add an intercept column to the covariate DataFrame
         values_column : A column name or column expression to test with linear regression. If a column name is provided,
                         ``genotype_df`` should have a column with this name and a numeric array type. If a column expression

--- a/python/glow/gwas/tests/test_approx_firth.py
+++ b/python/glow/gwas/tests/test_approx_firth.py
@@ -85,6 +85,7 @@ def test_full_firth_no_intercept():
     test_data = _get_test_data(use_offset=True, use_intercept=False)
     _compare_full_firth_beta(test_data, golden_firth_beta)
 
+
 def test_null_firth_fit_no_offset():
     golden_firth_beta = [
         -1.10598130,  # age
@@ -96,9 +97,25 @@ def test_null_firth_fit_no_offset():
         0.12025404  # intercept
     ]
     test_data = _get_test_data(use_offset=False, use_intercept=True)
-    fit = af.perform_null_firth_fit(test_data.phenotypes, test_data.covariates, 
-        ~np.isnan(test_data.phenotypes), None, includes_intercept=True)
+    fit = af.perform_null_firth_fit(test_data.phenotypes,
+                                    test_data.covariates,
+                                    ~np.isnan(test_data.phenotypes),
+                                    None,
+                                    includes_intercept=True)
     assert np.allclose(fit, test_data.covariates @ golden_firth_beta)
+
+
+def test_profile_big(rg):
+    n = 5000000
+    y = rg.integers(low=0, high=2, size=n).astype(np.float64)
+    C = np.random.random((n, 10))
+    C[:, 0] = 1
+    mask = ~np.isnan(y)
+    import cProfile
+    cProfile.runctx('af.perform_null_firth_fit(y, C, mask, None, True)',
+                    globals(),
+                    locals(),
+                    sort='cumtime')
 
 
 def _set_fid_iid_df(df):

--- a/python/glow/gwas/tests/test_approx_firth.py
+++ b/python/glow/gwas/tests/test_approx_firth.py
@@ -182,7 +182,7 @@ def compare_to_regenie(spark,
         cols = ['ID', 'pvalue', 'phenotype']
     assert_frame_equal(glowgr_df[cols], regenie_df[cols], check_dtype=False, check_less_precise=1)
 
-    correction_counts = glowgr_df.correction_succeeded.value_counts(dropna=False).to_dict()
+    correction_counts = glowgr_df.correctionSucceeded.value_counts(dropna=False).to_dict()
     if uncorrected > 0:
         # null in Spark DataFrame converts to nan in pandas
         assert correction_counts[np.nan] == uncorrected

--- a/python/glow/gwas/tests/test_approx_firth.py
+++ b/python/glow/gwas/tests/test_approx_firth.py
@@ -105,19 +105,6 @@ def test_null_firth_fit_no_offset():
     assert np.allclose(fit, test_data.covariates @ golden_firth_beta)
 
 
-def test_profile_big(rg):
-    n = 5000000
-    y = rg.integers(low=0, high=2, size=n).astype(np.float64)
-    C = np.random.random((n, 10))
-    C[:, 0] = 1
-    mask = ~np.isnan(y)
-    import cProfile
-    cProfile.runctx('af.perform_null_firth_fit(y, C, mask, None, True)',
-                    globals(),
-                    locals(),
-                    sort='cumtime')
-
-
 def _set_fid_iid_df(df):
     df['FID_IID'] = df['FID'].astype(str) + '_' + df['IID'].astype(str)
     return df.sort_values(by=['FID', 'IID']) \

--- a/python/glow/gwas/tests/test_approx_firth.py
+++ b/python/glow/gwas/tests/test_approx_firth.py
@@ -85,6 +85,21 @@ def test_full_firth_no_intercept():
     test_data = _get_test_data(use_offset=True, use_intercept=False)
     _compare_full_firth_beta(test_data, golden_firth_beta)
 
+def test_null_firth_fit_no_offset():
+    golden_firth_beta = [
+        -1.10598130,  # age
+        -0.06881673,  # oc
+        2.26887464,  # vic
+        -2.11140816,  # vicl
+        -0.78831694,  # vis
+        3.09601263,  # dia
+        0.12025404  # intercept
+    ]
+    test_data = _get_test_data(use_offset=False, use_intercept=True)
+    fit = af.perform_null_firth_fit(test_data.phenotypes, test_data.covariates, 
+        ~np.isnan(test_data.phenotypes), None, includes_intercept=True)
+    assert np.allclose(fit, test_data.covariates @ golden_firth_beta)
+
 
 def _set_fid_iid_df(df):
     df['FID_IID'] = df['FID'].astype(str) + '_' + df['IID'].astype(str)

--- a/python/glow/gwas/tests/test_lin_reg.py
+++ b/python/glow/gwas/tests/test_lin_reg.py
@@ -18,7 +18,7 @@ def run_linear_regression(genotype_df, phenotype_df, covariate_df, fit_intercept
     Y[~Y_mask] = 0
     Q = np.linalg.qr(C)[0]
     Y = gwas_fx._residualize_in_place(Y, Q)
-    Y_state = lr._create_YState(Y, phenotype_df, pd.DataFrame({}), Y_mask, np.float64)
+    Y_state = lr._create_YState(Y, phenotype_df, pd.DataFrame({}), Y_mask, np.float64, None)
     dof = C.shape[0] - C.shape[1] - 1
     pdf = pd.DataFrame({lr._VALUES_COLUMN_NAME: list(genotype_df.to_numpy('float64').T)})
 

--- a/python/glow/gwas/tests/test_lin_reg.py
+++ b/python/glow/gwas/tests/test_lin_reg.py
@@ -489,3 +489,18 @@ def test_subset_contigs(rg):
     state = lr._create_YState(phenotype_df.to_numpy(), phenotype_df, offset_df,
                               ~np.isnan(phenotype_df.to_numpy()), np.float64, ['chr1', 'chr3'])
     assert set(state.keys()) == set(['chr1', 'chr3'])
+
+
+@pytest.mark.min_spark('3')
+def test_subset_contigs_no_loco(spark, rg):
+    num_samples = 50
+    num_pheno = 5
+    genotype_df = pd.DataFrame(rg.random((num_samples, 3)))
+    phenotype_df = pd.DataFrame(rg.random((num_samples, num_pheno)))
+    offset_df = pd.DataFrame(rg.random((num_samples, num_pheno)))
+    # No error when contigs are provided without loco offsets
+    run_linear_regression_spark(spark,
+                                genotype_df,
+                                phenotype_df,
+                                offset_df=offset_df,
+                                contigs=['chr1'])

--- a/python/glow/gwas/tests/test_log_reg.py
+++ b/python/glow/gwas/tests/test_log_reg.py
@@ -344,3 +344,18 @@ def test_subset_contigs(spark, rg):
     state = lr._create_log_reg_state(spark, phenotype_df, offset_df, sql_type, C, 'none', True,
                                      ['chr1', 'chr3'])
     assert set(state.keys()) == set(['chr1', 'chr3'])
+
+
+@pytest.mark.min_spark('3')
+def test_subset_contigs_no_loco(spark, rg):
+    num_samples = 50
+    num_pheno = 5
+    genotype_df = pd.DataFrame(rg.random((num_samples, 3)))
+    phenotype_df = pd.DataFrame(random_phenotypes((num_samples, num_pheno), rg))
+    offset_df = pd.DataFrame(rg.random((num_samples, num_pheno)))
+    # No error when contigs are provided without loco offsets
+    run_logistic_regression_spark(spark,
+                                  genotype_df,
+                                  phenotype_df,
+                                  offset_df=offset_df,
+                                  contigs=['chr1'])

--- a/python/glow/gwas/tests/test_log_reg.py
+++ b/python/glow/gwas/tests/test_log_reg.py
@@ -327,6 +327,7 @@ def test_propagate_extra_cols(spark, rg):
     assert results.animal[results.animal == 'monkey'].all()
     assert results.columns.tolist() == ['genotype_idx', 'animal', 'tvalue', 'pvalue', 'phenotype']
 
+
 @pytest.mark.min_spark('3')
 def test_subset_contigs(spark, rg):
     num_samples = 50
@@ -338,8 +339,8 @@ def test_subset_contigs(spark, rg):
     offset_index = pd.MultiIndex.from_product([phenotype_df.index, contigs])
     offset_df = pd.DataFrame(rg.random((num_samples * 3, num_pheno)), index=offset_index)
     state = lr._create_log_reg_state(spark, phenotype_df, offset_df, sql_type, C, 'none', True,
-        None)
+                                     None)
     assert set(state.keys()) == set(contigs)
     state = lr._create_log_reg_state(spark, phenotype_df, offset_df, sql_type, C, 'none', True,
-        ['chr1', 'chr3'])
+                                     ['chr1', 'chr3'])
     assert set(state.keys()) == set(['chr1', 'chr3'])

--- a/python/glow/gwas/tests/test_log_reg.py
+++ b/python/glow/gwas/tests/test_log_reg.py
@@ -40,7 +40,7 @@ def statsmodels_baseline(genotype_df,
     if fit_intercept:
         covariate_df = sm.add_constant(covariate_df)
     p_values = []
-    t_values = []
+    chisq = []
     for phenotype in phenotype_df:
         for genotype_idx in range(genotype_df.shape[1]):
             mask = ~np.isnan(phenotype_df[phenotype].to_numpy())
@@ -56,10 +56,10 @@ def statsmodels_baseline(genotype_df,
             params = model.fit().params
             results = model.score_test(params,
                                        exog_extra=genotype_df.iloc[:, genotype_idx].array[mask])
-            t_values.append(results[0])
+            chisq.append(results[0])
             p_values.append(results[1])
     return pd.DataFrame({
-        'tvalue': np.concatenate(t_values),
+        'chisq': np.concatenate(chisq),
         'pvalue': np.concatenate(p_values),
         'phenotype': phenotype_df.columns.to_series().astype('str').repeat(genotype_df.shape[1])
     })
@@ -325,7 +325,7 @@ def test_propagate_extra_cols(spark, rg):
                                             extra_cols)
     assert sorted(results['genotype_idx'].tolist()) == [0] * 5 + [1] * 5 + [2] * 5
     assert results.animal[results.animal == 'monkey'].all()
-    assert results.columns.tolist() == ['genotype_idx', 'animal', 'tvalue', 'pvalue', 'phenotype']
+    assert results.columns.tolist() == ['genotype_idx', 'animal', 'chisq', 'pvalue', 'phenotype']
 
 
 @pytest.mark.min_spark('3')


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
- Add a `contigs` param for `linear_regression` and `logistic_regression`. When provided in conjunction with LOCO offsets, this indicates that we should only compute and broadcast driver side data for the selected contigs. From my tests, this is necessary with UKB sized datasets (otherwise Spark can OOM when serializing / deserializing the closure)
- Remove type checking for the offset parameter in the approximate firth correction. `nptyping` does not play nicely with optional params -- it previously raised an exception of the offset was `None`.
- Compute only the diagonal of the hat matrix in the approximate firth correction. The full matrix is size `n_samples x n_samples` and so cannot be materialized.
- Do not use `statsmodels` in the approximate firth correction. I profiled an approximate firth correction on 5M samples, and we spent a significant portion of the time initializing the statsmodels model and computing the Hessian at each iteration. The new implementation is ~50% faster.
- Rename the `logistic_regression` result field `correction_succeeded` to `correctionSucceeded`. Elsewhere in Glow we use camelCase for multiword column names, for example `contigName`.
- Rename the `logistic_regression` result field `tvalue` to `chisq`. The test statistic is chisq distributed for logistic regression.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

(Details)
