### PR TITLE
Improve register

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -21,7 +21,6 @@ import os
 def _spark_builder():
     return SparkSession.builder \
         .master("local[2]") \
-        .config("spark.hadoop.io.compression.codecs", "io.projectglow.sql.util.BGZFCodec") \
         .config("spark.ui.enabled", "false") \
         .config("spark.sql.execution.arrow.pyspark.enabled", "true")
 

--- a/core/src/main/scala/io/projectglow/Glow.scala
+++ b/core/src/main/scala/io/projectglow/Glow.scala
@@ -19,14 +19,14 @@ package io.projectglow
 import java.util.ServiceLoader
 
 import scala.collection.JavaConverters._
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.spark.sql.{DataFrame, SQLUtils, SparkSession}
-
 import io.projectglow.common.Named
+import io.projectglow.sql.util.BGZFCodec
 import io.projectglow.sql.{GlowSQLExtensions, SqlExtensionProvider}
 import io.projectglow.transformers.util.{SnakeCaseMap, StringUtils}
+import io.projectglow.vcf.VCFFileFormat
 
 /**
  * The entry point for all language specific functionality, meaning methods that cannot be expressed
@@ -49,7 +49,21 @@ class GlowBase {
 
     // Decrease the parquet columnar batch size (often necessary for large cohorts)
     spark.conf.set("spark.sql.parquet.columnarReaderBatchSize", "16")
+    // Add BGZ compression codec. Note that we do not enable for the enhanced GZIP codec, which automatically
+    // determines if an input file is gzipped or bgzipped, for all datasources since it confuses Spark's built in
+    // datasources.
+    spark.conf.set("io.compression.codecs", compressionCodecsWithBGZ(spark))
     sess
+  }
+
+  private def compressionCodecsWithBGZ(spark: SparkSession): String = {
+    val newCodecs = Seq(classOf[BGZFCodec].getCanonicalName)
+    (spark
+      .sessionState
+      .newHadoopConf()
+      .get("io.compression.codecs", "")
+      .split(",")
+      .filter(codec => codec.nonEmpty && !newCodecs.contains(codec)) ++ newCodecs).mkString(",")
   }
 
   /**

--- a/core/src/main/scala/io/projectglow/sql/util/BGZFCodec.scala
+++ b/core/src/main/scala/io/projectglow/sql/util/BGZFCodec.scala
@@ -19,14 +19,14 @@ package io.projectglow.sql.util
 import java.io.OutputStream
 
 import org.apache.hadoop.io.compress.{CompressionOutputStream, Compressor}
-import org.seqdoop.hadoop_bam.util.{DatabricksBGZFOutputStream, BGZFCodec => HBBGZFCodec}
+import org.seqdoop.hadoop_bam.util.{GlowBGZFOutputStream, BGZFCodec => HBBGZFCodec}
 
 /**
- * A copy of Hadoop-BAM's BGZF codec that returns a Databricks BGZF output stream.
+ * A copy of Hadoop-BAM's BGZF codec that returns a Glow BGZF output stream.
  */
 class BGZFCodec extends HBBGZFCodec {
   override def createOutputStream(out: OutputStream): CompressionOutputStream = {
-    new DatabricksBGZFOutputStream(out)
+    new GlowBGZFOutputStream(out)
   }
 
   override def createOutputStream(

--- a/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
+++ b/core/src/main/scala/io/projectglow/vcf/BigVCFDatasource.scala
@@ -24,7 +24,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkException
 import org.apache.spark.sql.{DataFrame, SQLUtils}
 import org.apache.spark.sql.sources.DataSourceRegister
-import org.seqdoop.hadoop_bam.util.DatabricksBGZFOutputStream
+import org.seqdoop.hadoop_bam.util.GlowBGZFOutputStream
 
 import io.projectglow.common.logging.{HlsEventRecorder, HlsTagValues}
 import io.projectglow.sql.BigFileDatasource
@@ -94,7 +94,7 @@ object BigVCFDatasource extends HlsEventRecorder {
           .getOrElse(baos)
 
         // Write an empty GZIP block iff this is the last partition
-        DatabricksBGZFOutputStream.setWriteEmptyBlockOnClose(outputStream, idx == nParts - 1)
+        GlowBGZFOutputStream.setWriteEmptyBlockOnClose(outputStream, idx == nParts - 1)
 
         // Write the header if this is the first nonempty partition
         val partitionWithHeader = if (firstNonemptyPartition == -1) 0 else firstNonemptyPartition

--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.execution.datasources._
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.sources.{DataSourceRegister, Filter}
 import org.apache.spark.sql.types._
-import org.seqdoop.hadoop_bam.util.{BGZFEnhancedGzipCodec, DatabricksBGZFOutputStream}
+import org.seqdoop.hadoop_bam.util.{BGZFEnhancedGzipCodec, GlowBGZFOutputStream}
 
 import io.projectglow.common.logging.{HlsEventRecorder, HlsTagValues}
 import io.projectglow.common.{CommonOptions, GlowLogging, SimpleInterval, VCFOptions, VariantSchemas, WithUtils}
@@ -493,7 +493,7 @@ private[projectglow] class VCFOutputWriterFactory(options: Map[String, String])
       dataSchema: StructType,
       context: TaskAttemptContext): OutputWriter = {
     val outputStream = CodecStreams.createOutputStream(context, new Path(path))
-    DatabricksBGZFOutputStream.setWriteEmptyBlockOnClose(outputStream, true)
+    GlowBGZFOutputStream.setWriteEmptyBlockOnClose(outputStream, true)
     val (headerLineSet, sampleIdInfo) =
       VCFHeaderUtils.parseHeaderLinesAndSamples(
         options,

--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -64,7 +64,8 @@ class VCFFileFormat extends TextBasedFileFormat with DataSourceRegister with Hls
     super.isSplitable(sparkSession, options, path) || {
       if (codecFactory == null) {
         codecFactory = new CompressionCodecFactory(
-          VCFFileFormat.hadoopConfWithBGZ(sparkSession.sessionState.newHadoopConf())
+          VCFFileFormat.hadoopConfWithBGZ(
+            sparkSession.sessionState.newHadoopConfWithOptions(options))
         )
       }
 
@@ -90,8 +91,9 @@ class VCFFileFormat extends TextBasedFileFormat with DataSourceRegister with Hls
     VCFFileFormat.requireWritableAsVCF(dataSchema)
     options.get(VCFOptions.COMPRESSION).foreach { compressionOption =>
       if (codecFactory == null) {
-        codecFactory =
-          new CompressionCodecFactory(VCFFileFormat.hadoopConfWithBGZ(job.getConfiguration))
+        codecFactory = new CompressionCodecFactory(
+          VCFFileFormat.hadoopConfWithBGZ(
+            sparkSession.sessionState.newHadoopConfWithOptions(options)))
       }
 
       val codec = codecFactory.getCodecByName(compressionOption)

--- a/core/src/main/scala/org/hadoop_bam/util/GlowBGZFOutputStream.scala
+++ b/core/src/main/scala/org/hadoop_bam/util/GlowBGZFOutputStream.scala
@@ -25,7 +25,7 @@ import org.apache.hadoop.io.compress.CompressionOutputStream
  * A copy of Hadoop-BAM's [[BGZFCompressionOutputStream]] that allows us to set
  * whether an empty gzip block should be written at the end of the output stream.
  */
-class DatabricksBGZFOutputStream(outputStream: OutputStream)
+class GlowBGZFOutputStream(outputStream: OutputStream)
     extends CompressionOutputStream(outputStream) {
 
   var writeEmptyBlockOnClose: Boolean = false
@@ -59,9 +59,9 @@ class DatabricksBGZFOutputStream(outputStream: OutputStream)
   }
 }
 
-object DatabricksBGZFOutputStream {
+object GlowBGZFOutputStream {
   def setWriteEmptyBlockOnClose(os: OutputStream, value: Boolean): Unit = os match {
-    case s: DatabricksBGZFOutputStream => s.writeEmptyBlockOnClose = value
+    case s: GlowBGZFOutputStream => s.writeEmptyBlockOnClose = value
     case _ => // No op
   }
 }

--- a/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
+++ b/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
@@ -18,7 +18,7 @@ package io.projectglow.sql
 
 import htsjdk.samtools.util.Log
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.{DebugFilesystem, SparkConf}
+import org.apache.spark.DebugFilesystem
 import org.scalatest.concurrent.{AbstractPatienceConfiguration, Eventually}
 import org.scalatest.time.{Milliseconds, Seconds, Span}
 import org.scalatest.{Args, FunSuite, Status, Tag}
@@ -26,7 +26,6 @@ import org.scalatest.{Args, FunSuite, Status, Tag}
 import io.projectglow.Glow
 import io.projectglow.SparkTestShim.SharedSparkSessionBase
 import io.projectglow.common.{GlowLogging, TestUtils}
-import io.projectglow.sql.util.BGZFCodec
 
 abstract class GlowBaseTest
     extends FunSuite
@@ -36,18 +35,11 @@ abstract class GlowBaseTest
     with TestUtils
     with JenkinsTestPatience {
 
-  override protected def sparkConf: SparkConf = {
-    super
-      .sparkConf
-      .set("spark.hadoop.io.compression.codecs", classOf[BGZFCodec].getCanonicalName)
-      .set(GlowConf.FAST_VCF_READER_ENABLED.key, "false") // TODO(hhd): Enable the fast reader once we're confident
-  }
-
   override def initializeSession(): Unit = ()
 
   override protected implicit def spark: SparkSession = {
-    val sess = SparkSession.builder().config(sparkConf).master("local[2]").getOrCreate()
-    Glow.register(sess)
+    val sess =
+      Glow.register(SparkSession.builder().config(sparkConf).master("local[2]").getOrCreate())
     SparkSession.setActiveSession(sess)
     Log.setGlobalLogLevel(Log.LogLevel.ERROR)
     sess

--- a/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
+++ b/core/src/test/scala/io/projectglow/sql/GlowBaseTest.scala
@@ -22,7 +22,6 @@ import org.apache.spark.DebugFilesystem
 import org.scalatest.concurrent.{AbstractPatienceConfiguration, Eventually}
 import org.scalatest.time.{Milliseconds, Seconds, Span}
 import org.scalatest.{Args, FunSuite, Status, Tag}
-
 import io.projectglow.Glow
 import io.projectglow.SparkTestShim.SharedSparkSessionBase
 import io.projectglow.common.{GlowLogging, TestUtils}
@@ -35,14 +34,11 @@ abstract class GlowBaseTest
     with TestUtils
     with JenkinsTestPatience {
 
-  override def initializeSession(): Unit = ()
-
-  override protected implicit def spark: SparkSession = {
-    val sess =
-      Glow.register(SparkSession.builder().config(sparkConf).master("local[2]").getOrCreate())
-    SparkSession.setActiveSession(sess)
+  override def initializeSession(): Unit = {
+    super.initializeSession()
+    Glow.register(spark, newSession = false)
+    SparkSession.setActiveSession(spark)
     Log.setGlobalLogLevel(Log.LogLevel.ERROR)
-    sess
   }
 
   protected def gridTest[A](testNamePrefix: String, testTags: Tag*)(params: Seq[A])(

--- a/core/src/test/scala/io/projectglow/sql/SqlExtensionProviderSuite.scala
+++ b/core/src/test/scala/io/projectglow/sql/SqlExtensionProviderSuite.scala
@@ -25,8 +25,8 @@ import org.apache.spark.sql.types.{DataType, IntegerType}
 import io.projectglow.GlowSuite
 
 class SqlExtensionProviderSuite extends GlowSuite {
-  override def beforeAll(): Unit = {
-    super.beforeAll()
+  override def beforeEach(): Unit = {
+    super.beforeEach()
     SqlExtensionProvider.registerFunctions(
       spark.sessionState.conf,
       spark.sessionState.functionRegistry,

--- a/docs/source/etl/sample-qc.rst
+++ b/docs/source/etl/sample-qc.rst
@@ -7,7 +7,7 @@ Sample Quality Control
 .. invisible-code-block: python
 
     import glow
-    glow.register(spark)
+    glow.register(spark, new_session=False)
 
 You can calculate quality control statistics on your variant data using Spark SQL functions, which
 can be expressed in Python, R, Scala, or SQL.

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -49,7 +49,7 @@ Glow requires Apache Spark 2.4.3 or later.
         .. code-block:: python
 
           import glow
-          glow.register(spark)
+          spark = glow.register(spark)
           df = spark.read.format('vcf').load(path)
 
     .. tab:: Scala

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -70,8 +70,8 @@ Glow requires Apache Spark 2.4.3 or later.
         .. code-block:: scala
 
           import io.projectglow.Glow
-          Glow.register(spark)
-          val df = spark.read.format("vcf").load(path)
+          val sess = Glow.register(spark)
+          val df = sess.read.format("vcf").load(path)
 
 
 Running in the cloud
@@ -80,9 +80,7 @@ Running in the cloud
 The easiest way to use Glow in the cloud is with the `Databricks Runtime for Genomics
 <https://docs.databricks.com/runtime/genomicsruntime.html>`_. However, it works with any cloud
 provider or Spark distribution. You need to install the maven package
-``io.project:glow-spark${spark_version}_${scala_version}:${glow_version}`` and optionally the Python frontend ``glow.py``. Also set the Spark configuration
-``spark.hadoop.io.compression.codecs`` to ``io.projectglow.sql.util.BGZFCodec`` in order to read and write
-BGZF-compressed files.
+``io.project:glow-spark${spark_version}_${scala_version}:${glow_version}`` and optionally the Python frontend ``glow.py``.
 
 Notebooks embedded in the docs
 ------------------------------

--- a/docs/source/tertiary/whole-genome-regression.rst
+++ b/docs/source/tertiary/whole-genome-regression.rst
@@ -7,7 +7,7 @@ GloWGR: Whole Genome Regression
 .. invisible-code-block: python
 
     import glow
-    glow.register(spark)
+    glow.register(spark, new_session=False)
 
     genotypes_vcf = 'test-data/gwas/genotypes.vcf.gz'
     covariates_csv = 'test-data/gwas/covariates.csv.gz'

--- a/python/glow/conftest.py
+++ b/python/glow/conftest.py
@@ -19,7 +19,7 @@ import pytest
 
 @pytest.fixture(autouse=True, scope="module")
 def add_glow(doctest_namespace, spark):
-    glow.register(spark)
+    glow.register(spark, new_session=False)
     doctest_namespace['Row'] = Row
     doctest_namespace['spark'] = spark
     doctest_namespace['lit'] = functions.lit

--- a/python/glow/glow.py
+++ b/python/glow/glow.py
@@ -72,7 +72,7 @@ def register(session: SparkSession, new_session: bool = True) -> SparkSession:
 
     Example:
         >>> import glow
-        >>> glow.register(spark)
+        >>> spark = glow.register(spark)
     """
     assert check_argument_types()
     sc = session._sc

--- a/python/glow/glow.py
+++ b/python/glow/glow.py
@@ -67,7 +67,7 @@ def register(session: SparkSession, new_session: bool = True) -> SparkSession:
         session: Spark session
         new_session: If ``True``, create a new Spark session using ``session.newSession()`` before registering
                      extensions. This may be necessary if you're using functions that register new
-                     analysis rules. The new session will have isolated UDFs, configurations, and temporary tables,
+                     analysis rules. The new session has isolated UDFs, configurations, and temporary tables,
                      but shares the existing ``SparkContext`` and cached data.
 
     Example:

--- a/python/glow/glow.py
+++ b/python/glow/glow.py
@@ -65,7 +65,7 @@ def register(session: SparkSession, new_session: bool = True) -> SparkSession:
 
     Args:
         session: Spark session
-        new_session: If ``True``, create a new Spark using ``session.newSession()`` before registering
+        new_session: If ``True``, create a new Spark session using ``session.newSession()`` before registering
                      extensions. This may be necessary if you're using functions that register new
                      analysis rules. The new session will have isolated UDFs, configurations, and temporary tables,
                      but shares the existing ``SparkContext`` and cached data.

--- a/python/glow/glow.py
+++ b/python/glow/glow.py
@@ -67,7 +67,8 @@ def register(session: SparkSession, new_session: bool=True) -> SparkSession:
         session: Spark session
         new_session: If ``True``, create a new Spark using ``session.newSession()`` before registering
                      extensions. This may be necessary if you're using functions that register new
-                     analysis rules.
+                     analysis rules. The new session will have isolated UDFs, configurations, and temporary tables,
+                     but shares the existing ``SparkContext`` and cached data.
 
     Example:
         >>> import glow

--- a/python/glow/glow.py
+++ b/python/glow/glow.py
@@ -59,7 +59,7 @@ def transform(operation: str,
     return output_df
 
 
-def register(session: SparkSession, new_session: bool=True) -> SparkSession:
+def register(session: SparkSession, new_session: bool = True) -> SparkSession:
     """
     Register SQL extensions and py4j converters for a Spark session.
 
@@ -76,7 +76,8 @@ def register(session: SparkSession, new_session: bool=True) -> SparkSession:
     """
     assert check_argument_types()
     sc = session._sc
-    return SparkSession(sc, session._jvm.io.projectglow.Glow.register(session._jsparkSession, new_session))
+    return SparkSession(
+        sc, session._jvm.io.projectglow.Glow.register(session._jsparkSession, new_session))
 
 
 # Register input converters in idempotent fashion

--- a/python/glow/glow.py
+++ b/python/glow/glow.py
@@ -59,19 +59,23 @@ def transform(operation: str,
     return output_df
 
 
-def register(session: SparkSession):
+def register(session: SparkSession, new_session: bool=True) -> SparkSession:
     """
     Register SQL extensions and py4j converters for a Spark session.
 
     Args:
         session: Spark session
+        new_session: If ``True``, create a new Spark using ``session.newSession()`` before registering
+                     extensions. This may be necessary if you're using functions that register new
+                     analysis rules.
 
     Example:
         >>> import glow
         >>> glow.register(spark)
     """
     assert check_argument_types()
-    session._jvm.io.projectglow.Glow.register(session._jsparkSession)
+    sc = session._sc
+    return SparkSession(sc, session._jvm.io.projectglow.Glow.register(session._jsparkSession, new_session))
 
 
 # Register input converters in idempotent fashion

--- a/python/glow/tests/test_register.py
+++ b/python/glow/tests/test_register.py
@@ -30,8 +30,7 @@ def test_no_register(spark):
 
 
 def test_register(spark):
-    sess = spark.newSession()
-    glow.register(sess)
+    sess = glow.register(spark)
     row_one = Row(Row(str_col='foo', int_col=1, bool_col=True))
     row_two = Row(Row(str_col='bar', int_col=2, bool_col=False))
     df = sess.createDataFrame([row_one, row_two], schema=['base_col'])
@@ -39,3 +38,10 @@ def test_register(spark):
                       .filter("added_col.str_col = 'foo'") \
                       .head()
     assert added_col_row.added_col.rev_str_col == 'oof'
+
+def test_new_session(spark):
+    sess = glow.register(spark, new_session=False)
+    assert sess._jsparkSession.equals(spark._jsparkSession)
+
+    sess = glow.register(spark, new_session=True)
+    assert not sess._jsparkSession.equals(spark._jsparkSession)

--- a/python/glow/tests/test_register.py
+++ b/python/glow/tests/test_register.py
@@ -39,6 +39,7 @@ def test_register(spark):
                       .head()
     assert added_col_row.added_col.rev_str_col == 'oof'
 
+
 def test_new_session(spark):
     sess = glow.register(spark, new_session=False)
     assert sess._jsparkSession.equals(spark._jsparkSession)


### PR DESCRIPTION
## What changes are proposed in this pull request?
While running the example notebooks on a Databricks cluster, I noticed that some functions can fail with confusing analysis errors if the cluster has run a query (including showing tables) before `glow.register` was called. To improve the default behavior, I added a `new_session` parameter to `register` so that this error can't happen by default.

In addition, I updated the register method to decrease the columnar parquet reader's batch size by default, which is typically necessary for large cohorts. This matches what we do in the Databricks genomics runtime.

I will update the notebooks in a forthcoming notebook cleanup PR.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
