### PR TITLE
Make mean_substitute faster

### DIFF
--- a/core/src/main/scala/io/projectglow/sql/dsl/package.scala
+++ b/core/src/main/scala/io/projectglow/sql/dsl/package.scala
@@ -24,15 +24,25 @@ package object dsl {
 
   trait ImplicitOperators {
     def expr: Expression
+
+    // Ensure that lambda variables have unique names for nested functions
+    private var lambdaCounter = 0
+    private def nextLambdaName(): String = {
+      lambdaCounter += 1
+      lambdaCounter.toString
+    }
+
     private def makeLambdaFunction(f: Expression => Expression): LambdaFunction = {
-      val x = UnresolvedNamedLambdaVariable(Seq("x"))
+      val x = UnresolvedNamedLambdaVariable(Seq(nextLambdaName()))
       LambdaFunction(f(x), Seq(x))
     }
+
     private def makeLambdaFunction(f: (Expression, Expression) => Expression): LambdaFunction = {
-      val x = UnresolvedNamedLambdaVariable(Seq("x"))
-      val y = UnresolvedNamedLambdaVariable(Seq("y"))
+      val x = UnresolvedNamedLambdaVariable(Seq(nextLambdaName()))
+      val y = UnresolvedNamedLambdaVariable(Seq(nextLambdaName()))
       LambdaFunction(f(x, y), Seq(x, y))
     }
+
     def arrayTransform(fn: Expression => Expression): Expression = {
       ArrayTransform(expr, makeLambdaFunction(fn))
     }

--- a/core/src/main/scala/io/projectglow/sql/expressions/MeanSubstitute.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/MeanSubstitute.scala
@@ -101,6 +101,8 @@ case class MeanSubstitute(array: Expression, missingValue: Expression)
     array.aggregate(
       createNamedStruct(Literal(0d), Literal(0L)),
       updateSumAndCountConditionally,
+      // Note: it's important that we perform the substitution in the finish function. Otherwise the mean is
+      // recomputed for each missing element.
       acc => array.arrayTransform(el => substituteWithMean(el, calculateMean(acc)))
     )
   }

--- a/core/src/main/scala/io/projectglow/sql/expressions/MeanSubstitute.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/MeanSubstitute.scala
@@ -83,17 +83,8 @@ case class MeanSubstitute(array: Expression, missingValue: Expression)
     )
   }
 
-  lazy val arrayMean: Expression = {
-    // Sum and count of non-missing values
-    array.aggregate(
-      createNamedStruct(Literal(0d), Literal(0L)),
-      updateSumAndCountConditionally,
-      calculateMean
-    )
-  }
-
-  def substituteWithMean(arrayElement: Expression): Expression = {
-    If(isMissing(arrayElement), arrayMean, arrayElement)
+  def substituteWithMean(arrayElement: Expression, meanExpr: Expression): Expression = {
+    If(isMissing(arrayElement), meanExpr, arrayElement)
   }
 
   override def rewrite: Expression = {
@@ -107,7 +98,10 @@ case class MeanSubstitute(array: Expression, missingValue: Expression)
         s"Missing value must be of numeric type; provided type is ${missingValue.dataType}.")
     }
 
-    // Replace missing values with the provided strategy
-    array.arrayTransform(substituteWithMean(_))
+    array.aggregate(
+      createNamedStruct(Literal(0d), Literal(0L)),
+      updateSumAndCountConditionally,
+      acc => array.arrayTransform(el => substituteWithMean(el, calculateMean(acc)))
+    )
   }
 }

--- a/core/src/test/scala/io/projectglow/tertiary/VariantQcExprsSuite.scala
+++ b/core/src/test/scala/io/projectglow/tertiary/VariantQcExprsSuite.scala
@@ -352,6 +352,18 @@ class VariantQcExprsSuite extends GlowBaseTest {
     assert(test == Seq(1.5, 1.5, 0.0, 1.0, 2.0, 3.0))
   }
 
+  test("mean substitute big array") {
+    val values = Array.fill(100000)(None: Option[Int])
+    values(0) = Some(1)
+    val test = spark
+      .createDataFrame(Seq(OptIntDatum(values)))
+      .selectExpr("mean_substitute(numbers)")
+      .collect()
+      .head
+      .getSeq[Double](0)
+    assert(test.forall(_ == 1))
+  }
+
   test("null array") {
     val test = spark
       .createDataFrame(Seq(Datum(null)))


### PR DESCRIPTION
Signed-off-by: Henry D <henrydavidge@gmail.com>

## What changes are proposed in this pull request?
Turns out that `mean_substitute` was accidentally `O(n^2)` in the worst case. We recomputed the mean for each missing element.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
