### PR TITLE
remove extraneous detail from quickstart docs

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -85,9 +85,9 @@ Getting started on Databricks
 
 The Databricks documentation shows how to get started with Glow on, 
 
-  - **Amazon Web Services** (AWS - `docs <https://docs.databricks.com/applications/genomics/genomics-libraries/index.html>`_)
-  - **Microsoft Azure** (`docs <https://docs.microsoft.com/en-us/azure/databricks/applications/genomics/genomics-libraries/>`_) 
-  - **Google Cloud Platform** (GCP - `docs <https://docs.gcp.databricks.com/applications/genomics/genomics-libraries/index.html>`_)
+  - **Amazon Web Services** (AWS - `docs <https://docs.databricks.com/applications/genomics/index.html>`_)
+  - **Microsoft Azure** (`docs <https://docs.microsoft.com/en-us/azure/databricks/applications/genomics>`_) 
+  - **Google Cloud Platform** (GCP - `docs <https://docs.gcp.databricks.com/applications/genomics/index.html>`_)
  
 Getting started on other cloud services
 ---------------------------------------


### PR DESCRIPTION
Signed-off-by: William Brandler <William.Brandler@databricks.com>

## What changes are proposed in this pull request?
Removing extraneous detail from the getting started guide.

Next PR will have the new quickstart notebooks for GWAS

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
