### PR TITLE
fix links

### DIFF
--- a/docs/dev/run-nb-test.py
+++ b/docs/dev/run-nb-test.py
@@ -83,13 +83,14 @@ def main(cli_profile, workspace_tmp_dir, source_dir, nbs):
                 for nb, run_info in nb_to_run_info.items():
                     base_msg = f"{nb} (Run ID {nb_to_run_id[nb]}) [{run_info['state']['life_cycle_state']}]"
                     if run_info['state']['life_cycle_state'] == 'INTERNAL_ERROR':
+                       print(base_msg, run_info['state']['result_state'], run_info['run_page_url'])
                        print("====================================")
                        print("|  Exiting due to internal error.  |")
                        print("====================================")
                        sys.exit(1)
                     if run_info['state']['life_cycle_state'] == 'TERMINATED':
+                        print(base_msg, run_info['state']['result_state'], run_info['run_page_url'])
                         if run_info['state']['result_state'] == 'FAILED':
-                            print(base_msg, run_info['state']['result_state'], run_info['run_page_url'])
                             print("===========================")
                             print("|    Some tasks failed.    |")
                             print("============================")

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -85,9 +85,9 @@ Getting started on Databricks
 
 The Databricks documentation shows how to get started with Glow on, 
 
-  - **Amazon Web Services** (AWS - `docs <https://docs.databricks.com/applications/genomics/index.html>`_)
-  - **Microsoft Azure** (`docs <https://docs.microsoft.com/en-us/azure/databricks/applications/genomics>`_) 
-  - **Google Cloud Platform** (GCP - `docs <https://docs.gcp.databricks.com/applications/genomics/index.html>`_)
+  - **Amazon Web Services** (AWS - `docs <https://docs.databricks.com/applications/genomics/genomics-libraries/glow.html>`_)
+  - **Microsoft Azure** (`docs <https://docs.microsoft.com/en-us/azure/databricks/applications/genomics/genomics-libraries/glow>`_) 
+  - **Google Cloud Platform** (GCP - `docs <https://docs.gcp.databricks.com/applications/genomics/genomics-libraries/glow.html>`_)
  
 Getting started on other cloud services
 ---------------------------------------


### PR DESCRIPTION
Signed-off-by: William Brandler <William.Brandler@databricks.com>

## What changes are proposed in this pull request?
The links to docs on databricks were not pointing directly to glow, so fixed them for AWS, Azure and GCP

Also the nightly continuous integration tests only outputs links for failed jobs, not jobs that were terminated due to an internal error

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
