### PR TITLE
update docker container to run on ubuntu 20.04

### DIFF
--- a/docker/databricks/build.sh
+++ b/docker/databricks/build.sh
@@ -15,9 +15,11 @@ docker build -t "${DOCKER_REPOSITORY}/with-r:9.1" r/
 docker build -t "${DOCKER_REPOSITORY}/genomics:9.1" genomics/
 docker build -t "${DOCKER_REPOSITORY}/databricks-hail:0.2.78" genomics-with-hail/
 docker build -t "${DOCKER_REPOSITORY}/databricks-glow:1.1.1" genomics-with-glow/
+docker build -t "${DOCKER_REPOSITORY}/databricks-glow:9.1" genomics-with-glow/
 popd
 
 docker push "${DOCKER_REPOSITORY}/databricks-hail:0.2.78"
 docker push "${DOCKER_REPOSITORY}/databricks-glow:1.1.1"
+docker push "${DOCKER_REPOSITORY}/databricks-glow:9.1"
 
 

--- a/docker/databricks/dbr/dbr9.1/genomics/Dockerfile
+++ b/docker/databricks/dbr/dbr9.1/genomics/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y \
     gnupg2 \
     software-properties-common \
     jq \
-    libjemalloc1 \
+    libjemalloc2 \
     libjemalloc-dev \
     libdbi-perl \
     libdbd-mysql-perl \

--- a/docker/databricks/dbr/dbr9.1/minimal/Dockerfile
+++ b/docker/databricks/dbr/dbr9.1/minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update \
   && apt-get install --yes \

--- a/docker/databricks/dbr/dbr9.1/r/Dockerfile
+++ b/docker/databricks/dbr/dbr9.1/r/Dockerfile
@@ -7,24 +7,23 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Set Databricks Run Time Version, This variable used to perform a runtime version check to see whether we can use notebook-scoped libraries in R.
 ENV DATABRICKS_RUNTIME_VERSION=9.1
 
-# We add RStudio's debian source to install the latest r-base version (4.1)
-# We are using the more secure long form of pgp key ID of marutter@gmail.com
-# based on these instructions (avoiding firewall issue for some users):
+# update indices
+# add the signing key (by Michael Rutter) for these repos
+# To verify key, run gpg --show-keys /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc 
+# Fingerprint: 298A3A825C0D65DFD57CBB651716619E084DAB9
 # https://cran.rstudio.com/bin/linux/ubuntu/#secure-apt
-RUN apt-get update \
-  && apt-get install --yes software-properties-common apt-transport-https \
-  && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 \
-  && gpg -a --export E298A3A825C0D65DFD57CBB651716619E084DAB9 | sudo apt-key add - \
-  && add-apt-repository -y 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu bionic-cran40/' \
-  && apt-get update \
+RUN apt update -qq \
   && apt-get install --yes \
+    software-properties-common \
+    dirmngr \
     libssl-dev \
     r-base \
     r-base-dev \
-  && add-apt-repository -r 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu bionic-cran40/' \
-  && apt-key del E298A3A825C0D65DFD57CBB651716619E084DAB9 \
+  && wget -qO- https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc | sudo tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc \
+  && add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu focal-cran40/" \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 
 # hwriterPlus is used by Databricks to display output in notebook cells
 # Rserve allows Spark to communicate with a local R process to run R code

--- a/docs/dev/jobs-config-hail.json
+++ b/docs/dev/jobs-config-hail.json
@@ -2,7 +2,7 @@
   "new_cluster": {
     "spark_version": "9.1.x-scala2.12",
     "node_type_id": "Standard_DS3_v2",
-    "num_workers": 2,
+    "num_workers": 4,
     "docker_image": {
         "url": "projectglow/databricks-hail:0.2.78"
     }

--- a/docs/dev/jobs-config.json
+++ b/docs/dev/jobs-config.json
@@ -2,7 +2,7 @@
   "new_cluster": {
     "spark_version": "9.1.x-scala2.12",
     "node_type_id": "Standard_DS4_v2",
-    "num_workers": 2,
+    "num_workers": 4,
     "docker_image": {
         "url": "projectglow/databricks-glow:1.1.1"
     }


### PR DESCRIPTION
Signed-off-by: William Brandler <William.Brandler@databricks.com>

## What changes are proposed in this pull request?
Update glow docker container to run on ubuntu 20.04 by default

To match Databricks runtime 9.x and above

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
