### PR TITLE
reorder dockerfile

### DIFF
--- a/docker/databricks/dbr/dbr9.1/genomics/Dockerfile
+++ b/docker/databricks/dbr/dbr9.1/genomics/Dockerfile
@@ -48,12 +48,6 @@ RUN apt-get update && apt-get install -y \
     libxml2 \
     libxml2-dev 
 
-# ===== Set up R genomics packages =================================================================
-
-RUN R -e "install.packages('sim1000G',dependencies=TRUE,repos='https://cran.rstudio.com')"\
- && R -e "install.packages('ukbtools',dependencies=TRUE,repos='https://cran.rstudio.com')"\
- && R -e "install.packages('qqman',dependencies=TRUE,repos='http://cran.us.r-project.org')"\
- && R -e "install.packages('bigsnpr',dependencies=TRUE,repos='http://cran.us.r-project.org')"
 
 # ===== Set up VEP environment =====================================================================
 
@@ -133,6 +127,13 @@ RUN CXX=/usr/bin/g++ && \
 
 ENV QQMAN_VERSION=1.0.6
 RUN /databricks/python3/bin/pip install qqman==$QQMAN_VERSION
+
+# ===== Set up R genomics packages =================================================================
+
+RUN R -e "install.packages('sim1000G',dependencies=TRUE,repos='https://cran.rstudio.com')"\
+ && R -e "install.packages('bigsnpr',dependencies=TRUE,repos='http://cran.us.r-project.org')"\
+ && R -e "install.packages('ukbtools',dependencies=TRUE,repos='https://cran.rstudio.com')"\
+ && R -e "install.packages('qqman',dependencies=TRUE,repos='http://cran.us.r-project.org')"
 
 # ===== Reset current directory ====================================================================
 


### PR DESCRIPTION
Signed-off-by: William Brandler <william.brandler@databricks.com>

## What changes are proposed in this pull request?
Was having issues getting the R Package bigsnpr working in Databricks after switching to Ubuntu 20.04, and after adding bgenix into this container. 

Discussed this with the author of bigsnpr, https://github.com/privefl/bigsnpr/issues/279. And he rightly pointed out that there was no clear reason why the tool should fail to install. We tested manually installing in databricks and this worked.

I decided to swap the order in which bigsnpr is built in two ways,

1. relative to bgenix
2. relative to other R packages in the container

And this worked. Not sure why, but can't hurt to reorder just in case



## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
