### PR TITLE
Support whitespaces for variant datasources

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -16,6 +16,7 @@
 
 package io.projectglow.vcf
 
+import java.net.URI
 import java.io.BufferedInputStream
 
 import scala.collection.JavaConverters._

--- a/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFFileFormat.scala
@@ -248,7 +248,7 @@ object VCFFileFormat {
    * The logic to parse the header is adapted from [[org.seqdoop.hadoop_bam.VCFRecordReader]].
    */
   def createVCFCodec(path: String, conf: Configuration): (VCFHeader, VCFCodec) = {
-    val hPath = new Path(path)
+    val hPath = new Path(new URI(path))
     val fs = hPath.getFileSystem(conf)
     WithUtils.withCloseable(fs.open(hPath)) { is =>
       val compressionCodec = new CompressionCodecFactory(conf).getCodec(hPath)


### PR DESCRIPTION
Signed-off-by: William Brandler <william.brandler@databricks.com>

## What changes are proposed in this pull request?
VCF reader does not support special characters such as whitespaces, but json and csv datasource readers do.

Right now a user would have to replace whitespaces with underscores, which may be time consuming if the number of files to convert is large.

https://github.com/projectglow/glow/issues/474

## How is this patch tested?
- [ ] Integration tests

Will need to write unit tests to check a path with whitespaces

(Details)
