### PR TITLE
docker container update

### DIFF
--- a/docker/databricks/build.sh
+++ b/docker/databricks/build.sh
@@ -13,14 +13,14 @@ docker build -t "${DOCKER_REPOSITORY}/dbfsfuse:9.1" dbfsfuse/
 docker build -t "${DOCKER_REPOSITORY}/standard:9.1" standard/
 docker build -t "${DOCKER_REPOSITORY}/with-r:9.1" r/
 docker build -t "${DOCKER_REPOSITORY}/genomics:9.1" genomics/
-docker build -t "${DOCKER_REPOSITORY}/databricks-hail:0.2.85" genomics-with-hail/
+docker build -t "${DOCKER_REPOSITORY}/databricks-hail:0.2.78" genomics-with-hail/
 docker build -t "${DOCKER_REPOSITORY}/databricks-glow-minus-ganglia:1.1.2" genomics-with-glow/
 docker build -t "${DOCKER_REPOSITORY}/databricks-glow:1.1.2" ganglia/
 docker build -t "${DOCKER_REPOSITORY}/databricks-glow-minus-ganglia:9.1" genomics-with-glow/
 docker build -t "${DOCKER_REPOSITORY}/databricks-glow:9.1" ganglia/
 popd
 
-docker push "${DOCKER_REPOSITORY}/databricks-hail:0.2.85"
+docker push "${DOCKER_REPOSITORY}/databricks-hail:0.2.78"
 docker push "${DOCKER_REPOSITORY}/databricks-glow:1.1.2"
 docker push "${DOCKER_REPOSITORY}/databricks-glow:9.1"
 docker push "${DOCKER_REPOSITORY}/databricks-glow-minus-ganglia:1.1.2"

--- a/docker/databricks/build.sh
+++ b/docker/databricks/build.sh
@@ -13,14 +13,14 @@ docker build -t "${DOCKER_REPOSITORY}/dbfsfuse:9.1" dbfsfuse/
 docker build -t "${DOCKER_REPOSITORY}/standard:9.1" standard/
 docker build -t "${DOCKER_REPOSITORY}/with-r:9.1" r/
 docker build -t "${DOCKER_REPOSITORY}/genomics:9.1" genomics/
-docker build -t "${DOCKER_REPOSITORY}/databricks-hail:0.2.78" genomics-with-hail/
+docker build -t "${DOCKER_REPOSITORY}/databricks-hail:0.2.85" genomics-with-hail/
 docker build -t "${DOCKER_REPOSITORY}/databricks-glow-minus-ganglia:1.1.2" genomics-with-glow/
 docker build -t "${DOCKER_REPOSITORY}/databricks-glow:1.1.2" ganglia/
 docker build -t "${DOCKER_REPOSITORY}/databricks-glow-minus-ganglia:9.1" genomics-with-glow/
 docker build -t "${DOCKER_REPOSITORY}/databricks-glow:9.1" ganglia/
 popd
 
-docker push "${DOCKER_REPOSITORY}/databricks-hail:0.2.78"
+docker push "${DOCKER_REPOSITORY}/databricks-hail:0.2.85"
 docker push "${DOCKER_REPOSITORY}/databricks-glow:1.1.2"
 docker push "${DOCKER_REPOSITORY}/databricks-glow:9.1"
 docker push "${DOCKER_REPOSITORY}/databricks-glow-minus-ganglia:1.1.2"

--- a/docker/databricks/dbr/dbr9.1/ganglia/Dockerfile
+++ b/docker/databricks/dbr/dbr9.1/ganglia/Dockerfile
@@ -1,4 +1,4 @@
-FROM projectglow/databricks-glow:1.1.2
+FROM projectglow/databricks-glow-minus-ganglia:1.1.2
 
 RUN apt-get update \
   && apt-get install -y openssh-server \

--- a/docker/databricks/dbr/dbr9.1/genomics-with-hail/Dockerfile
+++ b/docker/databricks/dbr/dbr9.1/genomics-with-hail/Dockerfile
@@ -5,7 +5,7 @@ FROM projectglow/genomics:9.1 AS builder
 # ===== Set up Hail ================================================================================
 
 # earliest Hail version supported by Spark3 is 0.2.67
-ENV HAIL_VERSION=0.2.85
+ENV HAIL_VERSION=0.2.78
  
 RUN apt-get update && apt-get install -y \
      openjdk-8-jre-headless \

--- a/docker/databricks/dbr/dbr9.1/genomics-with-hail/Dockerfile
+++ b/docker/databricks/dbr/dbr9.1/genomics-with-hail/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get update && apt-get install -y \
      rsync python-setuptools
 
 RUN /databricks/python3/bin/pip install \
-  numpy==1.19.2 \
   hail==$HAIL_VERSION
 
 RUN HAIL_JAR_PATH=$(find /databricks/python3 -name 'hail-all-spark.jar') && \

--- a/docker/databricks/dbr/dbr9.1/genomics-with-hail/Dockerfile
+++ b/docker/databricks/dbr/dbr9.1/genomics-with-hail/Dockerfile
@@ -5,7 +5,7 @@ FROM projectglow/genomics:9.1 AS builder
 # ===== Set up Hail ================================================================================
 
 # earliest Hail version supported by Spark3 is 0.2.67
-ENV HAIL_VERSION=0.2.78
+ENV HAIL_VERSION=0.2.85
  
 RUN apt-get update && apt-get install -y \
      openjdk-8-jre-headless \
@@ -14,7 +14,10 @@ RUN apt-get update && apt-get install -y \
      liblz4-1 liblz4-dev liblz4-tool \
      rsync python-setuptools
 
-RUN /databricks/python3/bin/pip install hail
+RUN /databricks/python3/bin/pip install \
+  numpy==1.19.2 \
+  hail==$HAIL_VERSION
+
 RUN HAIL_JAR_PATH=$(find /databricks/python3 -name 'hail-all-spark.jar') && \
   mkdir -p /databricks/jars && \
   cp $HAIL_JAR_PATH /databricks/jars/

--- a/docker/databricks/dbr/dbr9.1/genomics-with-hail/Dockerfile
+++ b/docker/databricks/dbr/dbr9.1/genomics-with-hail/Dockerfile
@@ -5,7 +5,7 @@ FROM projectglow/genomics:9.1 AS builder
 # ===== Set up Hail ================================================================================
 
 # earliest Hail version supported by Spark3 is 0.2.67
-ENV HAIL_VERSION=0.2.78
+ENV HAIL_VERSION=0.2.85
  
 RUN apt-get update && apt-get install -y \
      openjdk-8-jre-headless \

--- a/docker/databricks/dbr/dbr9.1/python/Dockerfile
+++ b/docker/databricks/dbr/dbr9.1/python/Dockerfile
@@ -24,11 +24,13 @@ RUN virtualenv -p python3.8 --system-site-packages /databricks/python3
 # These python libraries are used by Databricks notebooks and the Python REPL
 # You do not need to install pyspark - it is injected when the cluster is launched
 # Versions are intended to reflect DBR 9.1
+# except: 
+# downgrade ipython to maintain backwards compatibility with 7.x and 8.x runtimes
+# downgrade numpy to avoid issue here: https://stackoverflow.com/questions/63761366/numpy-linalg-linalgerror-svd-did-not-converge-in-linear-least-squares-on-first
 RUN /databricks/python3/bin/pip install \
   six==1.15.0 \
-  # downgrade ipython to maintain backwards compatibility with 7.x and 8.x runtimes
   ipython==7.22.0 \
-  numpy==1.19.2 \
+  numpy==1.18.5 \
   pandas==1.2.4 \
   pyarrow==4.0.0 \
   matplotlib==3.4.2 \

--- a/docker/databricks/dbr/dbr9.1/python/Dockerfile
+++ b/docker/databricks/dbr/dbr9.1/python/Dockerfile
@@ -34,7 +34,7 @@ RUN /databricks/python3/bin/pip install \
   pandas==1.2.4 \
   pyarrow==4.0.0 \
   matplotlib==3.4.2 \
-  jinja2==2.11.3 \
+  jinja2==3.0.3 \
   mlflow==1.19.0
 
 ENV MLFLOW_TRACKING_URI=databricks


### PR DESCRIPTION
## What changes are proposed in this pull request?
Upgraded Hail version from 0.2.78 to 0.2.85 -> explicitly pinned this version

downgrading the version of numpy for the glow docker container. 
This is to avoid this issue here:

https://stackoverflow.com/questions/63761366/numpy-linalg-linalgerror-svd-did-not-converge-in-linear-least-squares-on-first

## How is this patch tested?
- [x ] Manual tests

ran all notebooks to ensure they still work
confirmed correct version of numpy was installed with docker container `projectglow/databricks-glow:1.1.2`

![Screen Shot 2022-02-24 at 12 05 43 PM](https://user-images.githubusercontent.com/51180067/155599207-49063617-da7a-4ed1-87ae-87cd6ca865a9.png)