### PR TITLE
Fix Infinity/NaN parsing to allow full set of values from VCF specification

### DIFF
--- a/core/src/main/scala/io/projectglow/vcf/VCFLineToInternalRowConverter.scala
+++ b/core/src/main/scala/io/projectglow/vcf/VCFLineToInternalRowConverter.scala
@@ -397,11 +397,11 @@ class LineCtx(text: Text) {
       Double.NaN
     } else if (s == LineCtx.POS_NAN) {
       Double.NaN
-    } else if (s == LineCtx.INF) {
+    } else if (s == LineCtx.INF || s == LineCtx.INFINITY) {
       Double.PositiveInfinity
-    } else if (s == LineCtx.POS_INF) {
+    } else if (s == LineCtx.POS_INF || s == LineCtx.POS_INFINITY) {
       Double.PositiveInfinity
-    } else if (s == LineCtx.NEG_INF) {
+    } else if (s == LineCtx.NEG_INF || s == LineCtx.NEG_INFINITY) {
       Double.NegativeInfinity
     } else {
       s.toString.toDouble
@@ -537,10 +537,18 @@ class LineCtx(text: Text) {
   }
 }
 
+/**
+ * https://samtools.github.io/hts-specs/VCFv4.3.pdf
+ * Infinity/NAN values should match the following regex:
+ * ^[-+]?(INF|INFINITY|NAN)$ case insensitively
+ */
 object LineCtx {
   val INF = UTF8String.fromString("inf")
   val POS_INF = UTF8String.fromString("+inf")
   val NEG_INF = UTF8String.fromString("-inf")
+  val INFINITY = UTF8String.fromString("infinity")
+  val POS_INFINITY = UTF8String.fromString("+infinity")
+  val NEG_INFINITY = UTF8String.fromString("-infinity")
   val NAN = UTF8String.fromString("nan")
   val POS_NAN = UTF8String.fromString("+nan")
   val NEG_NAN = UTF8String.fromString("-nan")

--- a/test-data/vcf/test_withInfGenotype.vcf
+++ b/test-data/vcf/test_withInfGenotype.vcf
@@ -1,0 +1,11 @@
+##fileformat=VCFv4.1
+##contig=<ID=chr1,length=14640000>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GP,Number=1,Type=Float,Description="Genotype posterior probabilities in the range 0 to 1">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878
+chr1	4	.	C	T	.	.	.	GT:GP	./.:inf
+chr1	5	.	C	T	.	.	.	GT:GP	./.:InfinitY
+chr1	6	.	C	T	.	.	.	GT:GP	./.:+inF
+chr1	7	.	C	T	.	.	.	GT:GP	./.:+inFiniTy
+chr1	8	.	C	T	.	.	.	GT:GP	./.:-inF
+chr1	9	.	C	T	.	.	.	GT:GP	./.:-infinity

--- a/test-data/vcf/test_withInfQual.vcf
+++ b/test-data/vcf/test_withInfQual.vcf
@@ -8,3 +8,9 @@ chr1	2	.	C	T	-inf	.	.	GT	./.
 chr1	3	.	C	T	Inf	.	.	GT	./.
 chr1	3	.	C	T	+Inf	.	.	GT	./.
 chr1	3	.	C	T	-Inf	.	.	GT	./.
+chr1	4	.	C	T	infinity	.	.	GT	./.
+chr1	4	.	C	T	+infinity	.	.	GT	./.
+chr1	4	.	C	T	-infinity	.	.	GT	./.
+chr1	5	.	C	T	InfInitY	.	.	GT	./.
+chr1	5	.	C	T	+iNfiniTy	.	.	GT	./.
+chr1	5	.	C	T	-inFinIty	.	.	GT	./.

--- a/test-data/vcf/test_withNanGenotype.vcf
+++ b/test-data/vcf/test_withNanGenotype.vcf
@@ -1,0 +1,8 @@
+##fileformat=VCFv4.1
+##contig=<ID=chr1,length=14640000>
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GP,Number=1,Type=Float,Description="Genotype posterior probabilities in the range 0 to 1">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA12878
+chr1	1	.	C	T	.	.	.	GT:GP	./.:Nan
+chr1	2	.	C	T	.	.	.	GT:GP	./.:+naN
+chr1	3	.	C	T	.	.	.	GT:GP	./.:-nan


### PR DESCRIPTION


## What changes are proposed in this pull request?
Issue raised here: https://github.com/projectglow/glow/issues/517
In short, the VCF allows infinity/nan that follow this regex `^[-+]?(INF|INFINITY|NAN)$ case insensitively`

The code that parses the INFO and genotype columns do not allow the full range of valid values.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

Verified that unit tests failed before applying changes.
And unit tests passed after applying my changes.
