### PR TITLE
Update documentation for GFF schema for Alias field

### DIFF
--- a/docs/source/etl/gff.rst
+++ b/docs/source/etl/gff.rst
@@ -70,7 +70,8 @@ If no user-specified schema is provided (as in the example above), the data sour
 
      |-- ID: string (nullable = true)
      |-- Name: string (nullable = true)
-     |-- Alias: string (nullable = true)
+     |-- Alias: array (nullable = true)
+     |    |-- element: string (containsNull = true)
      |-- Parent: array (nullable = true)
      |    |-- element: string (containsNull = true)
      |-- Target: string (nullable = true)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Update documentation for GFF schema for `Alias` field

According to https://glow.readthedocs.io/en/latest/etl/gff.html#schema. `Alias` is defined as `string`. However, in the actual source code, it's defined as an array of `string`: https://github.com/projectglow/glow/blob/8b0bcd6b2f7320c3a5bd186bdcfa4707af303b47/core/src/main/scala/io/projectglow/common/schemas.scala#L171

Updating the documentation so it is matching exactly how it's internally represented. 

## How is this patch tested?
- [x] Unit tests
- [x] Integration tests
- [x] Manual tests

(Details)
