### PR TITLE
Add explicit timeout to linkcheck; ignore 1kg ftp

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -235,7 +235,11 @@ linkcheck_ignore = [
     r'http://www.sequenceontology.org*',
     # Captcha required
     r'https://gatk.broadinstitute.org*',
+    # Intermittently read timeouts
+    r'http://ftp.1000genomes.ebi.ac.uk*',
 ]
+
+linkcheck_timeout = 30
 
 
 # -- Autodoc options ---------------------------------------------------------


### PR DESCRIPTION
## What changes are proposed in this pull request?
The linkcheck had been occasionally hanging because 1) the 1kg ftp listing was flaky 2) there wasn't an explicit timeout set (although I thought there was a default according to sphinx docs...)

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
