### PR TITLE
Add explicit linkcheck timeout; ignore flaky 1kg link; fix setup.py syntax error

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -235,7 +235,11 @@ linkcheck_ignore = [
     r'http://www.sequenceontology.org*',
     # Captcha required
     r'https://gatk.broadinstitute.org*',
+    # Intermittently read timeouts
+    r'http://ftp.1000genomes.ebi.ac.uk*',
 ]
+
+linkcheck_timeout = 30
 
 
 # -- Autodoc options ---------------------------------------------------------

--- a/python/setup.py
+++ b/python/setup.py
@@ -25,7 +25,7 @@ setup(name='glow.py',
           'numpy>=1.23.5',
           'opt_einsum>=3.2.0',
           'pandas>=1.5.3',
-          'scipy>=1.10.0'
+          'scipy>=1.10.0',
           'statsmodels>=0.13.5',
           'typeguard>=2.13.3',
       ],


### PR DESCRIPTION
## What changes are proposed in this pull request?
The linkcheck had been occasionally hanging because 1) the 1kg ftp listing was flaky 2) there wasn't an explicit timeout set (although I thought there was a default according to sphinx docs...)

Also fixed an error in setup.py

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
