### PR TITLE
Don't report staged release dependencies

### DIFF
--- a/.github/workflows/scala-dependency.yml
+++ b/.github/workflows/scala-dependency.yml
@@ -14,3 +14,5 @@ jobs:
       - uses: scalacenter/sbt-dependency-submission@v2
         with:
           working-directory: './'
+          modules-ignore: stagedRelease stagedRelease_2.12 stagedRelease_2.13
+          configs-ignore: scala-tool scala-doc-tool


### PR DESCRIPTION
## What changes are proposed in this pull request?
Github's dependency page is still showing the dependencies we've updated since last release. Hopefully this will resolve it.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)
