### PR TITLE
Only enable scoverage during tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,8 +48,6 @@ ThisBuild / licenses += ("Apache-2.0", new URL("https://www.apache.org/licenses/
 // but not vice versa
 Compile / compileOrder := CompileOrder.JavaThenScala
 
-ThisBuild / coverageEnabled := true
-
 // Java options passed to Scala and Python tests
 val testJavaOptions = Vector(
   "-XX:+IgnoreUnrecognizedVMOptions",


### PR DESCRIPTION
## What changes are proposed in this pull request?
Assembly jars built with coverage on expect scoverage to be available at runtime.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)

To run Spark 4 tests against your PR, include `[SPARK4]` in the title.
