### PR TITLE
Suppress exception when closing stdin writer in pipe transformer

### DIFF
--- a/core/src/main/scala/io/projectglow/transformers/pipe/Piper.scala
+++ b/core/src/main/scala/io/projectglow/transformers/pipe/Piper.scala
@@ -19,12 +19,10 @@ package io.projectglow.transformers.pipe
 import java.lang.{IllegalStateException => ISE}
 import java.io._
 import java.util.concurrent.atomic.AtomicReference
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
-
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
@@ -32,8 +30,8 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SQLUtils, SparkSession}
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.util.CollectionAccumulator
-
 import io.projectglow.common.{GlowLogging, WithUtils}
+import org.apache.commons.lang3.exception.ExceptionUtils
 
 /**
  * Based on Spark's PipedRDD with the following modifications:
@@ -206,7 +204,7 @@ private[projectglow] class ProcessHelper(
         } catch {
           case t: Throwable => _childThreadException.set(t)
         } finally {
-          out.close()
+          Try(out.close())
         }
       }
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?
In unit tests we run programs that don't read from stdin. The process exits before the stream can be closed.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)

To run Spark 4 tests against your PR, include `[SPARK4]` in the title.
