### PR TITLE
[SPARK4] Rename quinary expression in Glow

### DIFF
--- a/core/src/main/scala/io/projectglow/sql/expressions/LogisticRegressionExpr.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/LogisticRegressionExpr.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.SQLUtils
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.TypeCheckResult
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, ExprCode}
-import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes, QuinaryExpression}
+import org.apache.spark.sql.catalyst.expressions.{Expression, ImplicitCastInputTypes, QuinaryOptionalExpression}
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.types.{ArrayType, DataType, DoubleType, StringType}
 import org.apache.spark.unsafe.types.UTF8String
@@ -139,7 +139,7 @@ case class LogisticRegressionExpr(
     covariates: Expression,
     test: Expression,
     offsetOption: Option[Expression])
-    extends QuinaryExpression
+    extends QuinaryOptionalExpression
     with ImplicitCastInputTypes {
 
   def this(

--- a/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/QuinaryOptionalExpression.scala
+++ b/core/src/main/scala/org/apache/spark/sql/catalyst/expressions/QuinaryOptionalExpression.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.codegen._
  * An expression with four inputs + 5th optional input.
  * The output is by default evaluated to null if any input is evaluated to null.
  */
-abstract class QuinaryExpression extends Expression {
+abstract class QuinaryOptionalExpression extends Expression {
 
   override def foldable: Boolean = children.forall(_.foldable)
 

--- a/core/src/test/scala/org/apache/spark/sql/catalyst/expressions/QuinaryOptionalExpressionSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/catalyst/expressions/QuinaryOptionalExpressionSuite.scala
@@ -27,7 +27,7 @@ case class testQuinaryExpr(
     child3: Expression,
     child4: Expression,
     child5: Option[Expression])
-    extends QuinaryExpression {
+    extends QuinaryOptionalExpression {
 
   override def dataType: DataType = IntegerType
 
@@ -55,7 +55,7 @@ case class testQuinaryExpr(
       child5 = Option(newChildren(5)))
 }
 
-class QuinaryExpressionSuite extends GlowBaseTest {
+class QuinaryOptionalExpressionSuite extends GlowBaseTest {
   test("nullSafeCodeGen for un-nullable expression with Some argument") {
     val ctx = new CodegenContext
     val testExpr = testQuinaryExpr(


### PR DESCRIPTION
## What changes are proposed in this pull request?
While testing the staged release, I found a naming collision between the quinary expression in Glow and the version that was later released in Spark. This could cause errors at runtime.

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)

To run Spark 4 tests against your PR, include `[SPARK4]` in the title.
