### PR TITLE
Use github action for PyPI publishing

### DIFF
--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -19,6 +19,8 @@ jobs:
     push-to-staging:
         runs-on: ubuntu-latest
         environment: Staging
+        permissions:
+          id-token: write # Necessary to fetch a token for PyPI publishing
         defaults:
           run:
             shell: bash -el {0}
@@ -76,8 +78,12 @@ jobs:
             - name: Build wheel and assembly jar
               run: bin/build --scala --python
 
-            - name: Push Python artifacts
-              run: (cd python && twine upload --repository-url https://test.pypi.org/legacy/ dist/*)
+            - name: Publish package distributions to TestPyPI
+              uses: pypa/gh-action-pypi-publish@release/v1
+              with:
+                repository-url: https://test.pypi.org/legacy/
+                packages-dir: python/dist/
+                verbose: true
 
             - name: Upload whl and assembly jar
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What changes are proposed in this pull request?
Twine doesn't natively support token fetching

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

(Details)

To run Spark 4 tests against your PR, include `[SPARK4]` in the title.
