### PR TITLE
Improve INFO field splitting logic; make variant splitting plan more …

### DIFF
--- a/core/src/main/scala/io/projectglow/transformers/splitmultiallelics/SplitMultiallelicsTransformer.scala
+++ b/core/src/main/scala/io/projectglow/transformers/splitmultiallelics/SplitMultiallelicsTransformer.scala
@@ -34,11 +34,13 @@ class SplitMultiallelicsTransformer extends DataFrameTransformer with HlsUsageLo
 
     // TODO: Log splitter usage
 
-    VariantSplitter.splitVariants(df)
+    val infoFieldsToSplit = options.get(SPLIT_INFO_FIELDS).map(_.split(',').map(_.trim()).toSeq)
+    VariantSplitter.splitVariants(df, infoFieldsToSplit)
 
   }
 }
 
 object SplitMultiallelicsTransformer {
+  val SPLIT_INFO_FIELDS = "split_info_fields"
   val SPLITTER_TRANSFORMER_NAME = "split_multiallelics"
 }

--- a/core/src/main/scala/io/projectglow/transformers/splitmultiallelics/VariantSplitter.scala
+++ b/core/src/main/scala/io/projectglow/transformers/splitmultiallelics/VariantSplitter.scala
@@ -17,9 +17,10 @@
 package io.projectglow.transformers.splitmultiallelics
 
 import com.google.common.annotations.VisibleForTesting
+import htsjdk.variant.vcf.VCFHeaderLineCount
 import io.projectglow.common.GlowLogging
 import io.projectglow.common.VariantSchemas._
-import io.projectglow.vcf.InternalRowToVariantContextConverter
+import io.projectglow.vcf.{InternalRowToVariantContextConverter, VCFSchemaInferrer}
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SQLUtils.structFieldsEqualExceptNullability
 import org.apache.spark.sql.functions._
@@ -65,7 +66,9 @@ private[projectglow] object VariantSplitter extends GlowLogging {
    * @param variantDf
    * @return dataframe of split variants
    */
-  def splitVariants(variantDf: DataFrame): DataFrame = {
+  def splitVariants(
+      variantDf: DataFrame,
+      infoFieldsToSplit: Option[Seq[String]] = None): DataFrame = {
 
     if (variantDf.schema.fieldNames.contains("attributes")) {
       // TODO: Unflattened INFO field splitting
@@ -100,7 +103,7 @@ private[projectglow] object VariantSplitter extends GlowLogging {
       )
 
     // Split INFO fields
-    val dfAfterInfoSplit = splitInfoFields(dfAfterAltAlleleSplit)
+    val dfAfterInfoSplit = splitInfoFields(dfAfterAltAlleleSplit, infoFieldsToSplit)
 
     // split genotypes fields, update alternateAlleles field, and drop the columns resulting from posexplode
     splitGenotypeFields(dfAfterInfoSplit)
@@ -116,22 +119,28 @@ private[projectglow] object VariantSplitter extends GlowLogging {
    * @return dataframe with split info fields
    */
   @VisibleForTesting
-  private[splitmultiallelics] def splitInfoFields(variantDf: DataFrame): DataFrame = {
-    variantDf
+  private[splitmultiallelics] def splitInfoFields(
+      variantDf: DataFrame,
+      infoFieldsToSplit: Option[Seq[String]]): DataFrame = {
+    val splittableFields = variantDf
       .schema
       .filter(field =>
-        field.name.startsWith(infoFieldPrefix) && field.dataType.isInstanceOf[ArrayType])
-      .foldLeft(
-        variantDf
-      )((df, field) =>
-        df.withColumn(
-          field.name,
-          when(
-            col(splitFromMultiAllelicField.name) &&
-            size(col(field.name)) === size(col(alternateAllelesField.name)),
-            array(expr(s"${field.name}[$splitAlleleIdxFieldName]"))
-          ).otherwise(col(field.name))
-        ))
+        field.name.startsWith(infoFieldPrefix) && field.dataType.isInstanceOf[ArrayType] &&
+        field.metadata.getString(VCFSchemaInferrer.VCF_HEADER_COUNT_KEY) == VCFHeaderLineCount
+          .A
+          .toString)
+      .map(_.name)
+
+    val fieldsToSplit = infoFieldsToSplit.getOrElse(splittableFields)
+
+    val columns = fieldsToSplit.map(field =>
+      field ->
+      when(
+        col(splitFromMultiAllelicField.name) &&
+        size(col(field)) === size(col(alternateAllelesField.name)),
+        array(expr(s"${field}[$splitAlleleIdxFieldName]"))
+      ).otherwise(col(field)))
+    variantDf.withColumns(columns.toMap)
   }
 
   /**
@@ -150,14 +159,13 @@ private[projectglow] object VariantSplitter extends GlowLogging {
       variantDf
     } else {
       // pull out genotypes subfields as new columns
-      val withExtractedFields = gSchema
+      val extractedFields = gSchema
         .get
         .fields
-        .foldLeft(variantDf)((df, field) =>
-          df.withColumn(
-            field.name,
-            expr(s"transform(${genotypesFieldName}, g -> g.${field.name})")))
-        .drop(genotypesFieldName)
+        .map(field =>
+          field.name ->
+          expr(s"transform(${genotypesFieldName}, g -> g.${field.name})"))
+      val withExtractedFields = variantDf.withColumns(extractedFields.toMap)
 
       // register the udf that genotypes splitter uses
       withExtractedFields
@@ -175,70 +183,60 @@ private[projectglow] object VariantSplitter extends GlowLogging {
       // WholestageCodegen is off for spark sql. Therefore, it is recommended to set "spark.sql.codegen.wholeStage" conf
       // to off when using this splitter.
 
-      gSchema
+      val updatedColumns = gSchema
         .get
         .fields
-        .foldLeft(withExtractedFields)((df, field) =>
-          field match {
-            case f
-                if structFieldsEqualExceptNullability(genotypeLikelihoodsField, f) |
-                structFieldsEqualExceptNullability(phredLikelihoodsField, f) |
-                structFieldsEqualExceptNullability(posteriorProbabilitiesField, f) =>
-              // update genotypes subfields that have colex order using the udf
-              df.withColumn(
-                f.name,
-                when(
-                  col(splitFromMultiAllelicField.name),
-                  expr(s"""transform(${f.name}, c ->
-                         |     filter(
-                         |        transform(
-                         |            c, (x, idx) ->
-                         |              if (
-                         |                  array_contains(
-                         |                      likelihoodSplitUdf(
-                         |                            size(${alternateAllelesField.name}) + 1,
-                         |                            size(${callsField.name}[0]),
-                         |                            $splitAlleleIdxFieldName + 1
-                         |                      ),
-                         |                      idx
-                         |                  ), x, null
-                         |              )
-                         |        ),
-                         |        x -> !isnull(x)
-                         |      )
-                         |   )""".stripMargin)
-                ).otherwise(col(f.name))
-              )
+        .collect {
+          case f
+              if structFieldsEqualExceptNullability(genotypeLikelihoodsField, f) |
+              structFieldsEqualExceptNullability(phredLikelihoodsField, f) |
+              structFieldsEqualExceptNullability(posteriorProbabilitiesField, f) =>
+            // update genotypes subfields that have colex order using the udf
+            f.name -> when(
+              col(splitFromMultiAllelicField.name),
+              expr(s"""transform(${f.name}, c ->
+                   |     filter(
+                   |        transform(
+                   |            c, (x, idx) ->
+                   |              if (
+                   |                  array_contains(
+                   |                      likelihoodSplitUdf(
+                   |                            size(${alternateAllelesField.name}) + 1,
+                   |                            size(${callsField.name}[0]),
+                   |                            $splitAlleleIdxFieldName + 1
+                   |                      ),
+                   |                      idx
+                   |                  ), x, null
+                   |              )
+                   |        ),
+                   |        x -> !isnull(x)
+                   |      )
+                   |   )""".stripMargin)
+            ).otherwise(col(f.name))
 
-            case f if structFieldsEqualExceptNullability(callsField, f) =>
-              // update GT calls subfield
-              df.withColumn(
-                f.name,
-                when(
-                  col(splitFromMultiAllelicField.name),
-                  expr(
-                    s"transform(${f.name}, " +
-                    s"c -> transform(c, x -> if(x == 0, x, if(x == $splitAlleleIdxFieldName + 1, 1, -1))))"
-                  )
-                ).otherwise(col(f.name))
+          case f if structFieldsEqualExceptNullability(callsField, f) =>
+            // update GT calls subfield
+            f.name -> when(
+              col(splitFromMultiAllelicField.name),
+              expr(
+                s"transform(${f.name}, " +
+                s"c -> transform(c, x -> if(x == 0, x, if(x == $splitAlleleIdxFieldName + 1, 1, -1))))"
               )
+            ).otherwise(col(f.name))
 
-            case f if f.dataType.isInstanceOf[ArrayType] =>
-              // update any ArrayType field with number of elements equal to number of alt alleles
-              df.withColumn(
-                f.name,
-                when(
-                  col(splitFromMultiAllelicField.name),
-                  expr(
-                    s"transform(${f.name}, c -> if(size(c) == size(${alternateAllelesField.name}) + 1," +
-                    s" array(c[0], c[$splitAlleleIdxFieldName + 1]), null))"
-                  )
-                ).otherwise(col(f.name))
+          case f if f.dataType.isInstanceOf[ArrayType] =>
+            // update any ArrayType field with number of elements equal to number of alt alleles
+            f.name -> when(
+              col(splitFromMultiAllelicField.name),
+              expr(
+                s"transform(${f.name}, c -> if(size(c) == size(${alternateAllelesField.name}) + 1," +
+                s" array(c[0], c[$splitAlleleIdxFieldName + 1]), null))"
               )
+            ).otherwise(col(f.name))
+        }
 
-            case _ =>
-              df
-          })
+      withExtractedFields
+        .withColumns(updatedColumns.toMap)
         .withColumn(genotypesFieldName, arrays_zip(gSchema.get.fieldNames.map(col(_)): _*))
         .drop(gSchema.get.fieldNames: _*)
     }

--- a/core/src/main/scala/io/projectglow/transformers/splitmultiallelics/VariantSplitter.scala
+++ b/core/src/main/scala/io/projectglow/transformers/splitmultiallelics/VariantSplitter.scala
@@ -126,6 +126,7 @@ private[projectglow] object VariantSplitter extends GlowLogging {
       .schema
       .filter(field =>
         field.name.startsWith(infoFieldPrefix) && field.dataType.isInstanceOf[ArrayType] &&
+        field.metadata.contains(VCFSchemaInferrer.VCF_HEADER_COUNT_KEY) &&
         field.metadata.getString(VCFSchemaInferrer.VCF_HEADER_COUNT_KEY) == VCFHeaderLineCount
           .A
           .toString)

--- a/core/src/test/scala/io/projectglow/SparkSuite.scala
+++ b/core/src/test/scala/io/projectglow/SparkSuite.scala
@@ -32,4 +32,12 @@ class SparkSuite extends GlowBaseTest {
   test("read file") {
     spark.read.text(s"$testDataHome/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf").count()
   }
+
+  test("print vcf schema") {
+    val schema =
+      spark.read.format("vcf").load(s"$testDataHome/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf").schema
+    schema.foreach { f =>
+      print(s"$f, ${f.metadata}\n")
+    }
+  }
 }

--- a/core/src/test/scala/io/projectglow/SparkSuite.scala
+++ b/core/src/test/scala/io/projectglow/SparkSuite.scala
@@ -32,12 +32,4 @@ class SparkSuite extends GlowBaseTest {
   test("read file") {
     spark.read.text(s"$testDataHome/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf").count()
   }
-
-  test("print vcf schema") {
-    val schema =
-      spark.read.format("vcf").load(s"$testDataHome/CEUTrio.HiSeq.WGS.b37.NA12878.20.21.vcf").schema
-    schema.foreach { f =>
-      print(s"$f, ${f.metadata}\n")
-    }
-  }
 }

--- a/docs/source/etl/variant-splitter.rst
+++ b/docs/source/etl/variant-splitter.rst
@@ -21,7 +21,9 @@ Split Multiallelic Variants
 
     - A given multiallelic row with :math:`n` ``ALT`` alleles is split to :math:`n` biallelic rows, each with one of the ``ALT`` alleles of the original multiallelic row. The ``REF`` allele in all split rows is the same as the ``REF`` allele in the multiallelic row.
 
-    - Each ``INFO`` field is appropriately split among split rows if it has the same number of elements as number of ``ALT`` alleles, otherwise it is repeated in all split rows. The boolean ``INFO`` field ``splitFromMultiAllelic`` is added/modified to reflect whether the new row is the result of splitting a multiallelic row through this transformation or not. A new ``INFO`` field called ``OLD_MULTIALLELIC`` is added to the DataFrame, which for each split row, holds the ``CHROM:POS:REF/ALT`` of its original multiallelic row. Note that the ``INFO`` field must be flattened (as explained :ref:`here<vcf>`) in order to be split by this transformer. Unflattened ``INFO`` fields (such as those inside an ``attributes`` field) will not be split, but just repeated in whole across all split rows.
+    - If the ``split_info_fields`` option is provided, only the specified INFO columns will be split
+
+    - If the ``split_info_fields`` option is not provided, ``INFO`` columns derived from VCF fields with number ``A`` will be split
 
     - Genotype fields for each sample are treated as follows: The ``GT`` field becomes biallelic in each row, where the original ``ALT`` alleles that are not present in that row are replaced with no call. The fields with number of entries equal to number of ``REF`` + ``ALT`` alleles, are properly split into rows, where in each split row, only entries corresponding to the ``REF`` allele as well as the ``ALT`` allele present in that row are kept. The fields which follow colex order (e.g., ``GL``, ``PL``, and ``GP``) are properly split between split rows where in each row only the elements corresponding to genotypes comprising of the ``REF`` and ``ALT`` alleles in that row are listed. Other genotype fields are just repeated over the split rows.
 
@@ -42,7 +44,20 @@ Split Multiallelic Variants
         20	101	.	A	ACCA	.	PASS	VC=INDEL;AC=3;AF=0.375;AN=8;OLD_MULTIALLELIC=20:101:A/ACCA/TCGG	GT:AD:DP:GQ:PL	0/1:2,15:30:99:2407,0,533
         20	101	.	A	TCGG	.	PASS	VC=INDEL;AC=2;AF=0.25;AN=8;OLD_MULTIALLELIC=20:101:A/ACCA/TCGG	GT:AD:DP:GQ:PL	0/.:2,31:30:99:2407,697,574
 
+Options
+=======
+The ``split_multiallelics`` transformer has the following options:
 
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Type
+     - Possible values and description
+   * - ``split_info_fields``
+     - string
+     - A comma separated list of info columns that should be split i.e., ``INFO_AC,INFO_AF``
+   
 Usage
 =====
 


### PR DESCRIPTION
…compact

## What changes are proposed in this pull request?
As reported in #537, the `split_mutliallelics` transformer splits INFO fields in an unexpected way for unbounded info fields. After this PR, we:
- By default only split info fields if we know they came from a VCF field with number `A` (alternate alleles)
- Allow the user to specify info fields in case the default behavior is not sufficient

In addition, I replaced the looped calls to `withColumn` with batched calls to `withColumns`. Calling `withColumn` many times is not recommended as it can result in very large plans: https://spark.apache.org/docs/3.1.3/api/python/reference/api/pyspark.sql.DataFrame.withColumn.html

## How is this patch tested?
- [x] Unit tests

(Describe any other testing)

To run Spark 4.0 tests, add `[SPARK4]` to the pull request title.