### PR TITLE
Make variant splitter work with Photon

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -218,6 +218,9 @@ jobs:
       - name: Build artifacts
         run: bin/build --scala --python
 
+      - name: Test assembly jar
+        run: java -cp core/target/**/glow*assembly*.jar io.projectglow.TestAssemblyJar
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: success() || failure()

--- a/build.sbt
+++ b/build.sbt
@@ -184,7 +184,7 @@ ThisBuild / coreDependencies := (providedSparkDependencies.value ++ testCoreDepe
   "com.github.broadinstitute" % "picard" % "2.27.5",
   "org.apache.commons" % "commons-lang3" % "3.14.0",
   // Fix versions of libraries that are depended on multiple times
-  "org.apache.hadoop" % "hadoop-client" % "3.4.0",
+  "org.apache.hadoop" % "hadoop-client" % "3.3.6",
   "io.netty" % "netty-all" % "4.1.96.Final",
   "io.netty" % "netty-handler" % "4.1.96.Final",
   "io.netty" % "netty-transport-native-epoll" % "4.1.96.Final",

--- a/build.sbt
+++ b/build.sbt
@@ -111,7 +111,6 @@ lazy val commonSettings = Seq(
   Test / test := ((Test / test) dependsOn (Test / headerCheck)).value,
   assembly / test := {},
   assembly / assemblyMergeStrategy := {
-    // Assembly jar is not executable
     case p if p.toLowerCase.contains("manifest.mf") =>
       MergeStrategy.discard
     case _ =>

--- a/core/src/main/scala/io/projectglow/TestAssemblyJar.scala
+++ b/core/src/main/scala/io/projectglow/TestAssemblyJar.scala
@@ -1,0 +1,7 @@
+package io.projectglow
+
+object TestAssemblyJar {
+  def main(args: Array[String]): Unit = {
+    println("Assembly jar works") // scalastyle:ignore
+  }
+}

--- a/core/src/main/scala/io/projectglow/TestAssemblyJar.scala
+++ b/core/src/main/scala/io/projectglow/TestAssemblyJar.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 The Glow Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.projectglow
 
 object TestAssemblyJar {

--- a/core/src/main/scala/io/projectglow/sql/expressions/glueExpressions.scala
+++ b/core/src/main/scala/io/projectglow/sql/expressions/glueExpressions.scala
@@ -17,16 +17,14 @@
 package io.projectglow.sql.expressions
 
 import io.projectglow.sql.util.{Rewrite, RewriteAfterResolution}
-
 import org.apache.spark.ml.linalg.Vectors
 import org.apache.spark.sql.SQLUtils
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.analysis.UnresolvedExtractValue
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodegenContext, CodegenFallback, ExprCode}
-import org.apache.spark.sql.catalyst.expressions.{Alias, CreateNamedStruct, ExpectsInputTypes, Expression, Generator, GenericInternalRow, GetStructField, ImplicitCastInputTypes, Literal, NamedExpression, UnaryExpression, Unevaluable}
+import org.apache.spark.sql.catalyst.expressions.{Add, Alias, BinaryExpression, CaseWhen, Cast, CreateNamedStruct, Divide, EqualTo, Exp, ExpectsInputTypes, Expression, Factorial, Generator, GenericInternalRow, GetStructField, If, ImplicitCastInputTypes, LessThan, Literal, Log, Multiply, NamedExpression, Pi, Round, Subtract, UnaryExpression, Unevaluable}
 import org.apache.spark.sql.catalyst.util.{ArrayData, GenericArrayData}
 import org.apache.spark.sql.types._
-
 import io.projectglow.SparkShim.newUnresolvedException
 
 /**
@@ -230,4 +228,91 @@ object VectorToArray {
   def toDoubleArray(input: Any): ArrayData = {
     new GenericArrayData(vectorType.deserialize(input).toArray)
   }
+}
+
+case class Comb(n: Expression, k: Expression) extends RewriteAfterResolution {
+  override def children: Seq[Expression] = Seq(n, k)
+
+  override def rewrite: Expression = {
+    Cast(
+      Round(
+        Exp(Subtract(Subtract(LogFactorial(n), LogFactorial(k)), LogFactorial(Subtract(n, k)))),
+        Literal(0)),
+      LongType)
+  }
+
+  override def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
+    copy(n = newChildren(0), k = newChildren(1))
+  }
+}
+
+/**
+ * Note: not user facing, approximate for n > 47
+ */
+case class LogFactorial(n: Expression) extends RewriteAfterResolution {
+  override def children: Seq[Expression] = Seq(n)
+
+  override def rewrite: Expression = {
+    Add
+    CaseWhen(
+      Seq(
+        (EqualTo(n, Literal(0)), Literal(0.0)),
+        (EqualTo(n, Literal(1)), Literal(0.0)),
+        (EqualTo(n, Literal(2)), Literal(0.693147180559945)),
+        (EqualTo(n, Literal(3)), Literal(1.7917594692280554)),
+        (EqualTo(n, Literal(4)), Literal(3.178053830347945)),
+        (EqualTo(n, Literal(5)), Literal(4.787491742782047)),
+        (EqualTo(n, Literal(6)), Literal(6.579251212010102)),
+        (EqualTo(n, Literal(7)), Literal(8.525161361065415)),
+        (EqualTo(n, Literal(8)), Literal(10.604602902745249)),
+        (EqualTo(n, Literal(9)), Literal(12.801827480081467)),
+        (EqualTo(n, Literal(10)), Literal(15.104412573075514)),
+        (EqualTo(n, Literal(11)), Literal(17.502307845873887)),
+        (EqualTo(n, Literal(12)), Literal(19.987214495661885)),
+        (EqualTo(n, Literal(13)), Literal(22.55216385312342)),
+        (EqualTo(n, Literal(14)), Literal(25.191221182738683)),
+        (EqualTo(n, Literal(15)), Literal(27.89927138384089)),
+        (EqualTo(n, Literal(16)), Literal(30.671860106080672)),
+        (EqualTo(n, Literal(17)), Literal(33.50507345013689)),
+        (EqualTo(n, Literal(18)), Literal(36.39544520803305)),
+        (EqualTo(n, Literal(19)), Literal(39.339884187199495)),
+        (EqualTo(n, Literal(20)), Literal(42.335616460753485)),
+        (EqualTo(n, Literal(21)), Literal(45.38013889847691)),
+        (EqualTo(n, Literal(22)), Literal(48.47118135183522)),
+        (EqualTo(n, Literal(23)), Literal(51.60667556776438)),
+        (EqualTo(n, Literal(24)), Literal(54.78472939811232)),
+        (EqualTo(n, Literal(25)), Literal(58.00360522298052)),
+        (EqualTo(n, Literal(26)), Literal(61.26170176100201)),
+        (EqualTo(n, Literal(27)), Literal(64.55753862700634)),
+        (EqualTo(n, Literal(28)), Literal(67.88974313718153)),
+        (EqualTo(n, Literal(29)), Literal(71.257038967168)),
+        (EqualTo(n, Literal(30)), Literal(74.65823634883017)),
+        (EqualTo(n, Literal(31)), Literal(78.0922235533153)),
+        (EqualTo(n, Literal(32)), Literal(81.55795945611503)),
+        (EqualTo(n, Literal(33)), Literal(85.05446701758152)),
+        (EqualTo(n, Literal(34)), Literal(88.58082754219768)),
+        (EqualTo(n, Literal(35)), Literal(92.1361756036871)),
+        (EqualTo(n, Literal(36)), Literal(95.7196945421432)),
+        (EqualTo(n, Literal(37)), Literal(99.33061245478743)),
+        (EqualTo(n, Literal(38)), Literal(102.96819861451381)),
+        (EqualTo(n, Literal(39)), Literal(106.63176026064346)),
+        (EqualTo(n, Literal(40)), Literal(110.32063971475738)),
+        (EqualTo(n, Literal(41)), Literal(114.03421178146169)),
+        (EqualTo(n, Literal(42)), Literal(117.77188139974507)),
+        (EqualTo(n, Literal(43)), Literal(121.53308151543864)),
+        (EqualTo(n, Literal(44)), Literal(125.3172711493569)),
+        (EqualTo(n, Literal(45)), Literal(129.12393363912722)),
+        (EqualTo(n, Literal(46)), Literal(132.95257503561632)),
+        (EqualTo(n, Literal(47)), Literal(136.80272263732635))
+      ),
+      Some(
+        Add(
+          Subtract(Multiply(Add(n, Literal(0.5)), Log(n)), n),
+          Multiply(Literal(0.5), Log(Multiply(Literal(2), Pi())))))
+    )
+  }
+  override def withNewChildrenInternal(newChildren: IndexedSeq[Expression]): Expression = {
+    copy(n = newChildren(0))
+  }
+
 }

--- a/core/src/main/scala/io/projectglow/transformers/splitmultiallelics/VariantSplitter.scala
+++ b/core/src/main/scala/io/projectglow/transformers/splitmultiallelics/VariantSplitter.scala
@@ -92,7 +92,7 @@ private[projectglow] object VariantSplitter extends GlowLogging {
             lit(":"),
             col(startField.name) + 1,
             lit(":"),
-            concat_ws("/", col(refAlleleField.name), col(alternateAllelesField.name))
+            array_join(array_prepend(col(alternateAllelesField.name), col(refAlleleField.name)), "/")
           )
         ).otherwise(lit(null))
       )

--- a/core/src/main/scala/io/projectglow/transformers/splitmultiallelics/VariantSplitter.scala
+++ b/core/src/main/scala/io/projectglow/transformers/splitmultiallelics/VariantSplitter.scala
@@ -92,7 +92,9 @@ private[projectglow] object VariantSplitter extends GlowLogging {
             lit(":"),
             col(startField.name) + 1,
             lit(":"),
-            array_join(array_prepend(col(alternateAllelesField.name), col(refAlleleField.name)), "/")
+            array_join(
+              array_prepend(col(alternateAllelesField.name), col(refAlleleField.name)),
+              "/")
           )
         ).otherwise(lit(null))
       )

--- a/core/src/test/scala/io/projectglow/transformers/splitmultiallelics/VariantSplitterSuite.scala
+++ b/core/src/test/scala/io/projectglow/transformers/splitmultiallelics/VariantSplitterSuite.scala
@@ -20,6 +20,7 @@ import io.projectglow.common.GlowLogging
 import io.projectglow.common.VariantSchemas._
 import io.projectglow.sql.GlowBaseTest
 import io.projectglow.transformers.splitmultiallelics.VariantSplitter._
+import org.apache.commons.math3.util.CombinatoricsUtils
 import org.apache.spark.sql.functions._
 
 class VariantSplitterSuite extends GlowBaseTest with GlowLogging {
@@ -284,76 +285,73 @@ class VariantSplitterSuite extends GlowBaseTest with GlowLogging {
       }
   }
 
-  def testRefAltColexOrderIdxArray(
-      numAlleles: Int,
-      ploidy: Int,
-      altAlleleIdx: Int,
-      expected: Array[Int]): Unit = {
-    if (numAlleles < 2 || ploidy < 1 || altAlleleIdx < 1 || altAlleleIdx > numAlleles - 1) {
-      try {
-        refAltColexOrderIdxArray(numAlleles, ploidy, altAlleleIdx)
-      } catch {
-        case _: IllegalArgumentException => // Succeed
-        case _: Throwable => fail()
-      }
-    } else {
-      assert(refAltColexOrderIdxArray(numAlleles, ploidy, altAlleleIdx) === expected)
-    }
-  }
-
+  case class ColexOrderTestCase(ploidy: Int, altAlleleIdx: Int, truth: Array[Int])
   test("test refAltColexOrderIdxArray") {
-    // exception cases
-    testRefAltColexOrderIdxArray(1, 2, 1, Array())
-    testRefAltColexOrderIdxArray(2, 0, 1, Array())
-    testRefAltColexOrderIdxArray(2, 2, 0, Array())
-    testRefAltColexOrderIdxArray(2, 2, 2, Array())
-
-    // valid cases
-    testRefAltColexOrderIdxArray(2, 1, 1, Array(0, 1))
-    testRefAltColexOrderIdxArray(3, 1, 1, Array(0, 1))
-    testRefAltColexOrderIdxArray(4, 1, 1, Array(0, 1))
-    testRefAltColexOrderIdxArray(3, 1, 2, Array(0, 2))
-    testRefAltColexOrderIdxArray(4, 1, 2, Array(0, 2))
-    testRefAltColexOrderIdxArray(4, 1, 3, Array(0, 3))
-    testRefAltColexOrderIdxArray(5, 1, 4, Array(0, 4))
-
-    testRefAltColexOrderIdxArray(2, 2, 1, Array(0, 1, 2))
-    testRefAltColexOrderIdxArray(3, 2, 1, Array(0, 1, 2))
-    testRefAltColexOrderIdxArray(4, 2, 1, Array(0, 1, 2))
-    testRefAltColexOrderIdxArray(3, 2, 2, Array(0, 3, 5))
-    testRefAltColexOrderIdxArray(4, 2, 2, Array(0, 3, 5))
-    testRefAltColexOrderIdxArray(4, 2, 3, Array(0, 6, 9))
-    testRefAltColexOrderIdxArray(5, 2, 4, Array(0, 10, 14))
-    testRefAltColexOrderIdxArray(6, 2, 5, Array(0, 15, 20))
-    testRefAltColexOrderIdxArray(7, 2, 6, Array(0, 21, 27))
-    testRefAltColexOrderIdxArray(8, 2, 7, Array(0, 28, 35))
-    testRefAltColexOrderIdxArray(9, 2, 8, Array(0, 36, 44))
-    testRefAltColexOrderIdxArray(10, 2, 9, Array(0, 45, 54))
-    testRefAltColexOrderIdxArray(11, 2, 10, Array(0, 55, 65))
-
-    testRefAltColexOrderIdxArray(2, 3, 1, Array(0, 1, 2, 3))
-    testRefAltColexOrderIdxArray(3, 3, 1, Array(0, 1, 2, 3))
-    testRefAltColexOrderIdxArray(4, 3, 1, Array(0, 1, 2, 3))
-    testRefAltColexOrderIdxArray(3, 3, 2, Array(0, 4, 7, 9))
-    testRefAltColexOrderIdxArray(4, 3, 2, Array(0, 4, 7, 9))
-    testRefAltColexOrderIdxArray(4, 3, 3, Array(0, 10, 16, 19))
-    testRefAltColexOrderIdxArray(5, 3, 4, Array(0, 20, 30, 34))
-
-    testRefAltColexOrderIdxArray(2, 4, 1, Array(0, 1, 2, 3, 4))
-    testRefAltColexOrderIdxArray(3, 4, 1, Array(0, 1, 2, 3, 4))
-    testRefAltColexOrderIdxArray(4, 4, 1, Array(0, 1, 2, 3, 4))
-    testRefAltColexOrderIdxArray(3, 4, 2, Array(0, 5, 9, 12, 14))
-    testRefAltColexOrderIdxArray(4, 4, 2, Array(0, 5, 9, 12, 14))
-    testRefAltColexOrderIdxArray(4, 4, 3, Array(0, 15, 25, 31, 34))
-    testRefAltColexOrderIdxArray(5, 4, 4, Array(0, 35, 55, 65, 69))
-    testRefAltColexOrderIdxArray(6, 4, 4, Array(0, 35, 55, 65, 69))
-    testRefAltColexOrderIdxArray(6, 4, 5, Array(0, 70, 105, 120, 125))
-
-    testRefAltColexOrderIdxArray(6, 5, 1, Array(0, 1, 2, 3, 4, 5))
-    testRefAltColexOrderIdxArray(6, 5, 2, Array(0, 6, 11, 15, 18, 20))
-    testRefAltColexOrderIdxArray(6, 5, 3, Array(0, 21, 36, 46, 52, 55))
-    testRefAltColexOrderIdxArray(6, 5, 4, Array(0, 56, 91, 111, 121, 125))
-    testRefAltColexOrderIdxArray(6, 5, 5, Array(0, 126, 196, 231, 246, 251))
+    val cases = Seq(
+      ColexOrderTestCase(1, 1, Array(0, 1)),
+      ColexOrderTestCase(1, 1, Array(0, 1)),
+      ColexOrderTestCase(1, 1, Array(0, 1)),
+      ColexOrderTestCase(1, 2, Array(0, 2)),
+      ColexOrderTestCase(1, 2, Array(0, 2)),
+      ColexOrderTestCase(1, 3, Array(0, 3)),
+      ColexOrderTestCase(1, 4, Array(0, 4)),
+      ColexOrderTestCase(2, 1, Array(0, 1, 2)),
+      ColexOrderTestCase(2, 1, Array(0, 1, 2)),
+      ColexOrderTestCase(2, 1, Array(0, 1, 2)),
+      ColexOrderTestCase(2, 2, Array(0, 3, 5)),
+      ColexOrderTestCase(2, 2, Array(0, 3, 5)),
+      ColexOrderTestCase(2, 3, Array(0, 6, 9)),
+      ColexOrderTestCase(2, 4, Array(0, 10, 14)),
+      ColexOrderTestCase(2, 5, Array(0, 15, 20)),
+      ColexOrderTestCase(2, 6, Array(0, 21, 27)),
+      ColexOrderTestCase(2, 7, Array(0, 28, 35)),
+      ColexOrderTestCase(2, 8, Array(0, 36, 44)),
+      ColexOrderTestCase(2, 9, Array(0, 45, 54)),
+      ColexOrderTestCase(2, 10, Array(0, 55, 65)),
+      ColexOrderTestCase(3, 1, Array(0, 1, 2, 3)),
+      ColexOrderTestCase(3, 1, Array(0, 1, 2, 3)),
+      ColexOrderTestCase(3, 1, Array(0, 1, 2, 3)),
+      ColexOrderTestCase(3, 2, Array(0, 4, 7, 9)),
+      ColexOrderTestCase(3, 2, Array(0, 4, 7, 9)),
+      ColexOrderTestCase(3, 3, Array(0, 10, 16, 19)),
+      ColexOrderTestCase(3, 4, Array(0, 20, 30, 34)),
+      ColexOrderTestCase(4, 1, Array(0, 1, 2, 3, 4)),
+      ColexOrderTestCase(4, 1, Array(0, 1, 2, 3, 4)),
+      ColexOrderTestCase(4, 1, Array(0, 1, 2, 3, 4)),
+      ColexOrderTestCase(4, 2, Array(0, 5, 9, 12, 14)),
+      ColexOrderTestCase(4, 2, Array(0, 5, 9, 12, 14)),
+      ColexOrderTestCase(4, 3, Array(0, 15, 25, 31, 34)),
+      ColexOrderTestCase(4, 4, Array(0, 35, 55, 65, 69)),
+      ColexOrderTestCase(4, 4, Array(0, 35, 55, 65, 69)),
+      ColexOrderTestCase(4, 5, Array(0, 70, 105, 120, 125)),
+      ColexOrderTestCase(5, 1, Array(0, 1, 2, 3, 4, 5)),
+      ColexOrderTestCase(5, 2, Array(0, 6, 11, 15, 18, 20)),
+      ColexOrderTestCase(5, 3, Array(0, 21, 36, 46, 52, 55)),
+      ColexOrderTestCase(5, 4, Array(0, 56, 91, 111, 121, 125)),
+      ColexOrderTestCase(5, 5, Array(0, 126, 196, 231, 246, 251))
+    )
+    val df = spark
+      .createDataFrame(cases)
+      .withColumn(
+        "glow",
+        expr(
+          "transform(array_repeat(0, ploidy + 1), (el, i) -> comb(ploidy + altAlleleIdx, ploidy) - comb(ploidy + altAlleleIdx - i, ploidy - i))")
+      )
+      .where("glow != truth")
+    assert(df.count() == 0)
   }
 
+  case class BinomialTestCase(n: Int, k: Int, coeff: Long)
+  test("binomial coefficient function") {
+    val cases = Range(0, 45).flatMap { n =>
+      Range.inclusive(0, n).map { k =>
+        BinomialTestCase(n, k, CombinatoricsUtils.binomialCoefficient(n, k))
+      }
+    }
+    val df = spark
+      .createDataFrame(cases)
+      .withColumn("glow", expr("comb(n, k)"))
+      .where("glow != coeff")
+    assert(df.count() == 0)
+  }
 }

--- a/functions.yml
+++ b/functions.yml
@@ -485,11 +485,11 @@ gwas_functions:
           doc: An array of genotype structs with ``calls`` field
       returns: An array of integers containing the number of alternate alleles in each call array
 
-
+# These functions are intended to only be called from Glow code. They are available in SQL but not in the Scala
+# or Python APIs.
 private:
   functions:
-    - name: Comb
-      doc: Compute binomial coefficient
+    - name: comb
       since: 2.1.0
       expr_class: io.projectglow.sql.expressions.Comb
       args:

--- a/functions.yml
+++ b/functions.yml
@@ -490,6 +490,7 @@ gwas_functions:
 private:
   functions:
     - name: comb
+      doc: Compute binomial coefficient
       since: 2.1.0
       expr_class: io.projectglow.sql.expressions.Comb
       args:

--- a/functions.yml
+++ b/functions.yml
@@ -484,3 +484,16 @@ gwas_functions:
         - name: genotypes
           doc: An array of genotype structs with ``calls`` field
       returns: An array of integers containing the number of alternate alleles in each call array
+
+
+private:
+  functions:
+    - name: Comb
+      doc: Compute binomial coefficient
+      since: 2.1.0
+      expr_class: io.projectglow.sql.expressions.Comb
+      args:
+        - name: n
+          doc: n
+        - name: k
+          doc: k

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.2.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.5")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.10.0")

--- a/python/render_template.py
+++ b/python/render_template.py
@@ -151,5 +151,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     function_groups = yaml.load(open(FUNCTIONS_YAML), Loader=yaml.SafeLoader)
+    del function_groups['private']
     groups_to_render = prepare_definitions(function_groups)
     render_template(args.template_path, args.output_path, groups=groups_to_render)


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Fix Glow assembly jar
- Move colex order function to SQL
- Replace functions that aren't implemented in Photon
- Modifying splitter to avoid any copying or manipulation of the genotype struct when not splitting

## How is this patch tested?
- [x] Unit tests

Manual testing to make sure everything runs in Photon now

To run Spark 4.0 tests, add `[SPARK4]` to the pull request title.