### PR TITLE
Fix critical security vulnerability and CI workflow issues

### DIFF
--- a/.github/workflows/scala-dependency.yml
+++ b/.github/workflows/scala-dependency.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
           echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add -
           sudo apt-get update
           sudo apt-get install -y sbt
       

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
           echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add -
           sudo apt-get update
           sudo apt-get install -y sbt
 
@@ -185,7 +185,7 @@ jobs:
         run: |
           echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" | sudo tee /etc/apt/sources.list.d/sbt.list
           echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | sudo tee /etc/apt/sources.list.d/sbt_old.list
-          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
+          curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add -
           sudo apt-get update
           sudo apt-get install -y sbt
 

--- a/build.sbt
+++ b/build.sbt
@@ -189,7 +189,9 @@ ThisBuild / coreDependencies := (providedSparkDependencies.value ++ testCoreDepe
   "io.netty" % "netty-transport-native-epoll" % "4.1.96.Final",
   "com.github.samtools" % "htsjdk" % "3.0.5",
   "org.yaml" % "snakeyaml" % "2.2",
-  "com.univocity" % "univocity-parsers" % "2.9.1"
+  "com.univocity" % "univocity-parsers" % "2.9.1",
+  // Fix CVE: Upgrade Avro to 1.11.4+ to fix Arbitrary Code Execution vulnerability
+  "org.apache.avro" % "avro" % "1.11.4"
 )).map(_.exclude("com.google.code.findbugs", "jsr305"))
 
 lazy val root = (project in file(".")).aggregate(core, python, docs)


### PR DESCRIPTION
Security Fixes:
- Upgrade Apache Avro to 1.11.4 to fix CVE (Arbitrary Code Execution) Resolves Dependabot alert #80

CI/CD Fixes:
- Fix apt-key add command missing '-' argument in all workflows
- Ensures GPG key is properly read from stdin during sbt installation

All workflow sbt installation steps now correctly import the repository GPG key.

## What changes are proposed in this pull request?
(Details)

## How is this patch tested?
- [x] Unit tests

(Describe any other testing)

To run Spark 4.0 tests, add `[SPARK4]` to the pull request title.